### PR TITLE
make Craisin load its API token from mix config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,10 +26,6 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-# Import environment specific config. This must remain at the bottom
-# of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
-
 # Configure phoenix generators
 config :phoenix, :generators,
   migration: true,
@@ -38,3 +34,11 @@ config :phoenix, :generators,
 config :scrivener_html,
   routes_helper: Changelog.Router.Helpers,
   view_style: :semantic
+
+# Configures Craisin
+config :changelog, Craisin,
+  api_token: System.get_env("CM_API_TOKEN")
+
+# Import environment specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+import_config "#{Mix.env}.exs"

--- a/lib/craisin.ex
+++ b/lib/craisin.ex
@@ -4,7 +4,11 @@ defmodule Craisin do
   require Logger
 
   defp auth do
-    Base.encode64((System.get_env("CM_API_TOKEN") || "") <> ":x")
+    Application.get_env(:changelog, Craisin, [])
+    |> Keyword.get(:api_token, "")
+    |> Kernel.||("")
+    |> Kernel.<>(":x")
+    |> Base.encode64
   end
 
   defp process_url(url) do


### PR DESCRIPTION
@gerhard good call on using mix config. I just want to confirm that this means we don't need that environment variable at compile time before merging this.