### PR TITLE
Remove unused mark_for_deletion functionality

### DIFF
--- a/web/models/episode_channel.ex
+++ b/web/models/episode_channel.ex
@@ -3,7 +3,6 @@ defmodule Changelog.EpisodeChannel do
 
   schema "episode_channels" do
     field :position, :integer
-    field :delete, :boolean, virtual: true
 
     belongs_to :channel, Changelog.Channel
     belongs_to :episode, Changelog.Episode
@@ -12,7 +11,7 @@ defmodule Changelog.EpisodeChannel do
   end
 
   @required_fields ~w(position)
-  @optional_fields ~w(episode_id channel_id delete)
+  @optional_fields ~w(episode_id channel_id)
 
   def changeset(model, params \\ %{}) do
     model

--- a/web/models/episode_channel.ex
+++ b/web/models/episode_channel.ex
@@ -17,18 +17,9 @@ defmodule Changelog.EpisodeChannel do
   def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> mark_for_deletion()
   end
 
   def by_position do
     from p in __MODULE__, order_by: p.position
-  end
-
-  defp mark_for_deletion(changeset) do
-    if get_change(changeset, :delete) do
-      %{changeset | action: :delete}
-    else
-      changeset
-    end
   end
 end

--- a/web/models/episode_guest.ex
+++ b/web/models/episode_guest.ex
@@ -3,7 +3,6 @@ defmodule Changelog.EpisodeGuest do
 
   schema "episode_guests" do
     field :position, :integer
-    field :delete, :boolean, virtual: true
 
     belongs_to :person, Changelog.Person
     belongs_to :episode, Changelog.Episode
@@ -12,7 +11,7 @@ defmodule Changelog.EpisodeGuest do
   end
 
   @required_fields ~w(position)
-  @optional_fields ~w(episode_id person_id delete)
+  @optional_fields ~w(episode_id person_id)
 
   def changeset(model, params \\ %{}) do
     model

--- a/web/models/episode_guest.ex
+++ b/web/models/episode_guest.ex
@@ -17,18 +17,9 @@ defmodule Changelog.EpisodeGuest do
   def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> mark_for_deletion()
   end
 
   def by_position do
     from p in __MODULE__, order_by: p.position
-  end
-
-  defp mark_for_deletion(changeset) do
-    if get_change(changeset, :delete) do
-      %{changeset | action: :delete}
-    else
-      changeset
-    end
   end
 end

--- a/web/models/episode_host.ex
+++ b/web/models/episode_host.ex
@@ -3,7 +3,6 @@ defmodule Changelog.EpisodeHost do
 
   schema "episode_hosts" do
     field :position, :integer
-    field :delete, :boolean, virtual: true
 
     belongs_to :person, Changelog.Person
     belongs_to :episode, Changelog.Episode
@@ -12,7 +11,7 @@ defmodule Changelog.EpisodeHost do
   end
 
   @required_fields ~w(position)
-  @optional_fields ~w(episode_id person_id delete)
+  @optional_fields ~w(episode_id person_id)
 
   def changeset(model, params \\ %{}) do
     model

--- a/web/models/episode_host.ex
+++ b/web/models/episode_host.ex
@@ -17,7 +17,6 @@ defmodule Changelog.EpisodeHost do
   def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> mark_for_deletion()
   end
 
   def by_position do
@@ -26,13 +25,5 @@ defmodule Changelog.EpisodeHost do
 
   def build_and_preload({person, position}) do
     %__MODULE__{position: position, person_id: person.id} |> Repo.preload(:person)
-  end
-
-  defp mark_for_deletion(changeset) do
-    if get_change(changeset, :delete) do
-      %{changeset | action: :delete}
-    else
-      changeset
-    end
   end
 end

--- a/web/models/episode_sponsor.ex
+++ b/web/models/episode_sponsor.ex
@@ -9,7 +9,6 @@ defmodule Changelog.EpisodeSponsor do
     field :link_url, :string
     field :description, :string
 
-    field :delete, :boolean, virtual: true
 
     belongs_to :episode, Changelog.Episode
     belongs_to :sponsor, Changelog.Sponsor
@@ -18,7 +17,7 @@ defmodule Changelog.EpisodeSponsor do
   end
 
   @required_fields ~w(position title link_url)
-  @optional_fields ~w(episode_id sponsor_id description delete)
+  @optional_fields ~w(episode_id sponsor_id description)
 
   def changeset(model, params \\ %{}) do
     model

--- a/web/models/episode_sponsor.ex
+++ b/web/models/episode_sponsor.ex
@@ -24,7 +24,6 @@ defmodule Changelog.EpisodeSponsor do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> validate_format(:link_url, Regexp.http, message: Regexp.http_message)
-    |> mark_for_deletion()
   end
 
   def by_position do
@@ -33,13 +32,5 @@ defmodule Changelog.EpisodeSponsor do
 
   def newest_first(query) do
     from s in query, order_by: [desc: s.inserted_at]
-  end
-
-  defp mark_for_deletion(changeset) do
-    if get_change(changeset, :delete) do
-      %{changeset | action: :delete}
-    else
-      changeset
-    end
   end
 end

--- a/web/models/podcast_host.ex
+++ b/web/models/podcast_host.ex
@@ -3,7 +3,6 @@ defmodule Changelog.PodcastHost do
 
   schema "podcast_hosts" do
     field :position, :integer
-    field :delete, :boolean, virtual: true
 
     belongs_to :podcast, Changelog.Podcast
     belongs_to :person, Changelog.Person
@@ -12,7 +11,7 @@ defmodule Changelog.PodcastHost do
   end
 
   @required_fields ~w(position)
-  @optional_fields ~w(podcast_id person_id delete)
+  @optional_fields ~w(podcast_id person_id)
 
   def changeset(model, params \\ %{}) do
     model

--- a/web/models/podcast_host.ex
+++ b/web/models/podcast_host.ex
@@ -17,18 +17,9 @@ defmodule Changelog.PodcastHost do
   def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> mark_for_deletion()
   end
 
   def by_position do
     from p in __MODULE__, order_by: p.position
-  end
-
-  defp mark_for_deletion(changeset) do
-    if get_change(changeset, :delete) do
-      %{changeset | action: :delete}
-    else
-      changeset
-    end
   end
 end

--- a/web/models/post_channel.ex
+++ b/web/models/post_channel.ex
@@ -3,7 +3,6 @@ defmodule Changelog.PostChannel do
 
   schema "post_channels" do
     field :position, :integer
-    field :delete, :boolean, virtual: true
 
     belongs_to :channel, Changelog.Channel
     belongs_to :post, Changelog.Post
@@ -12,7 +11,7 @@ defmodule Changelog.PostChannel do
   end
 
   @required_fields ~w(position)
-  @optional_fields ~w(post_id channel_id delete)
+  @optional_fields ~w(post_id channel_id)
 
   def changeset(model, params \\ %{}) do
     model

--- a/web/models/post_channel.ex
+++ b/web/models/post_channel.ex
@@ -17,18 +17,9 @@ defmodule Changelog.PostChannel do
   def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> mark_for_deletion()
   end
 
   def by_position do
     from p in __MODULE__, order_by: p.position
-  end
-
-  defp mark_for_deletion(changeset) do
-    if get_change(changeset, :delete) do
-      %{changeset | action: :delete}
-    else
-      changeset
-    end
   end
 end


### PR DESCRIPTION
Found some unused functionality while spelunking the codebase. Of course this might be used with tools you have not published. Below is what I wrote in the first commit:

---

* The functionality provided by this was never used in other modules.
* Record deletion is always done using Repo.delete directly.
* No tests exercised this code.
* Code is almost identical to same [pattern shown in Ecto.Changelog docs](https://hexdocs.pm/ecto/Ecto.Changeset.html#module-on-replace).
* Code appears to have been pasted from model-to-model as more were added.

---

Thanks for open-sourcing, I learnt a lot, including the `mark_for_deletion` pattern.