### PR TITLE
Update mix.ex to prevent some warnnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule Changelog.Mixfile do
      compilers: [:phoenix] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     aliases: aliases,
-     deps: deps]
+     aliases: aliases(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application.


### PR DESCRIPTION
On the newest version of elixir calling a function with arity 0 without parenthesis generates a warning