### PR TITLE
Add script to generate policy html documents base on legal repo

### DIFF
--- a/script/convert_policy
+++ b/script/convert_policy
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+
+brew install markdown
+
+# convert with markdown tool
+git clone --depth 1 https://github.com/thechangelog/legal && \
+cd legal && \
+markdown privacy.md > ../../web/templates/page/privacy.html.eex && \
+markdown terms.md > ../../web/templates/page/terms.html.eex 
+
+# clean up
+rm -rf ./legal/
+
+# Next Step adjust the static page when needed

--- a/web/router.ex
+++ b/web/router.ex
@@ -76,6 +76,8 @@ defmodule Changelog.Router do
     get "/soundcheck", PageController, :soundcheck
     get "/team", PageController, :team
     get "/live", PageController, :live
+    get "/privacy", PageController, :privacy
+    get "/terms", PageController, :terms
 
     get "/nightly", PageController, :nightly
     get "/nightly/confirmed", PageController, :nightly_confirmed

--- a/web/templates/layout/_footer.html.eex
+++ b/web/templates/layout/_footer.html.eex
@@ -19,6 +19,8 @@
       <a class="footer_link" href="https://www.instagram.com/thechangelog/">Instagram</a>
       <%= link "Newsletters", to: page_path(@conn, :weekly), class: "footer_link" %>
       <a class="footer_link" href="https://github.com/thechangelog/changelog.com">Source</a>
+      <a class="footer_link" href="/terms">Terms</a>
+      <a class="footer_link" href="/privacy">Privacy</a>
     </nav>
   </footer>
 </section>

--- a/web/templates/page/privacy.html.eex
+++ b/web/templates/page/privacy.html.eex
@@ -1,0 +1,92 @@
+<article class="section content">
+  <div class="container container--has-padding container--skinny">
+    <header class="content_header">
+      <h2>The Changelog Privacy Policy</h2>
+    </header>
+    <div class="content_body">
+
+<p>Please read this document carefully before accessing or using The Changelog.</p>
+
+<h2>Introduction</h2>
+
+<h3>English, not Legalese.</h3>
+
+<p>Most Terms of Service and Privacy Policy documents are unreadable. They are written by and for lawyers, and in our opinion, they are not very effective.</p>
+
+<p>Because we believe in establishing long-term relationships with our readers and listeners, we decided to use plain English instead, to make our terms as clear as possible.</p>
+
+<p>Please don't forget that we are real people: take a look at our company page to get to know us a little. We're not perfect, but we're trying, and we genuinely care about you.</p>
+
+<p>When you read "The Changelog" or "we" as mentioned in this document, it refers to changelog.com (contact information), its affiliates and agents.</p>
+
+<p>Should you have other questions or concerns about this document, please get in touch <a href="http://thechangelog.com/contact/">using our contact form</a> or <a href="https://github.com/thechangelog/legal/issues/new">by submitting an issue on GitHub</a>.</p>
+
+<h3>About this document</h3>
+
+<p>This is a living document and is <a href="https://github.com/thechangelog/legal/blob/master/privacy.md">open source on GitHub</a>.</p>
+
+<p>If you read something in this this document and it rubs you the wrong way, or you feel something should be added, please <a href="https://github.com/thechangelog/legal/issues/new">submit an issue</a> or <a href="http://thechangelog.com/contact/">contact us</a>.</p>
+
+<p>We don't amend this document for any particular subscriber, but if your changes apply to all of our subscriber, we'll be happy to update it for everyone.</p>
+
+<p>We will likely improve this document over time. By continuing to use the site, you will implicitly accept the changes we make.</p>
+
+<p>Your access and use of The Changelog is always subject to the most current version of this document.</p>
+
+<p>This document was adapted from <a href="http://automattic.com/privacy/">Automattic</a>.</p>
+
+<hr />
+
+<h2>Privacy Policy</h2>
+
+<p>Your privacy is critically important to us.</p>
+
+<p>At The Changelog we have a few fundamental principles:</p>
+
+<ul>
+<li>We don't ask you for personal information unless we truly need it. (We can't stand services that ask you for things like your gender or income level for no apparent reason.)</li>
+<li>We don't share your personal information with anyone except to comply with the law, develop our products, or protect our rights.</li>
+<li>We don't store personal information on our servers unless required for the on-going operation of one of our services.</li>
+<li>In our products, we aim to make it as simple as possible for you to control what's visible to the public, seen by search engines, kept private, and permanently deleted.</li>
+</ul>
+
+<p>If you have questions about deleting or correcting your personal data please contact our support team.</p>
+
+<p>RIZN Media, LLC ("The Changelog", "our", "we") operates thechangelog.com. It is The Changelog's policy to respect your privacy regarding any information we may collect while operating our websites.</p>
+
+<h3>Website Visitors</h3>
+
+<p>Like most website operators, The Changelog collects non-personally-identifying information of the sort that web browsers and servers typically make available, such as the browser type, language preference, referring site, and the date and time of each visitor request. Our purpose in collecting non-personally identifying information is to better understand how our visitors use our website and services. From time to time, we may release non-personally-identifying information in the aggregate, e.g., by publishing a report on trends in the usage of its website.</p>
+
+<p>The Changelog also collects potentially personally-identifying information like Internet Protocol (IP) addresses for logged in users and for users viewing apps shared with The Changelog. The Changelog only discloses logged in user and commenter IP addresses under the same circumstances that it uses and discloses personally-identifying information as described below, except that blog commenter IP addresses are visible and disclosed to the administrators of the blog where the comment was left.</p>
+
+<h3>Gathering of Personally-Identifying Information</h3>
+
+<p>Certain visitors to The Changelog choose to interact with it in ways that require us to gather personally-identifying information. The amount and type of information that we gather depends on the nature of the interaction. For example, we ask visitors who sign up for an account at The Changelog.com to provide a name and email address. Those who engage in transactions with The Changelog – by purchasing a Pro membership, for example, are asked to provide additional information, including as necessary the personal and financial information required to process those transactions. In each case, The Changelog collects such information only insofar as is necessary or appropriate to fulfill the purpose of the visitor's interaction with The Changelog. The Changelog does not disclose personally-identifying information other than as described below. And visitors can always refuse to supply personally-identifying information, with the caveat that it may prevent them from engaging in certain website-related activities.</p>
+
+<h3>Aggregated Statistics</h3>
+
+<p>The Changelog may collect statistics about the behavior of our visitors. For instance, we track views and clicks on a post to determine usage and engagement. The Changelog may display this information publicly or provide it to others. However, The Changelog does not disclose personally-identifying information other than as described below.</p>
+
+<h3>Protection of Certain Personally-Identifying Information</h3>
+
+<p>The Changelog discloses potentially personally-identifying and personally-identifying information only to those of its employees, contractors and affiliated organizations that (i) need to know that information in order to process it on The Changelog's behalf or to provide services available at The Changelog's websites, and (ii) that have agreed not to disclose it to others. Some of those employees, contractors and affiliated organizations may be located outside of your home country; by using The Changelog's websites, you consent to the transfer of such information to them. The Changelog will not rent or sell potentially personally-identifying and personally-identifying information to anyone. Other than to its employees, contractors and affiliated organizations, as described above, The Changelog discloses potentially personally-identifying and personally-identifying information only in response to a subpoena, court order or other governmental request, or when The Changelog believes in good faith that disclosure is reasonably necessary to protect the property or rights of The Changelog, third parties or the public at large. If you are a registered user of an The Changelog website and have supplied your email address, The Changelog may occasionally send you an email to tell you about new features, solicit your feedback, or just keep you up to date with what's going on with The Changelog and our products. We primarily use our various product blogs to communicate this type of information, so we expect to keep this type of email to a minimum. If you send us a request (for example via a support email or via one of our feedback mechanisms), we reserve the right to publish it in order to help us clarify or respond to your request or to help us support other users. The Changelog takes all measures reasonably necessary to protect against the unauthorized access, use, alteration or destruction of potentially personally-identifying and personally-identifying information.</p>
+
+<h3>Cookies</h3>
+
+<p>A cookie is a string of information that a website stores on a visitor's computer, and that the visitor's browser provides to the website each time the visitor returns. The Changelog uses cookies to help The Changelog identify and track visitors, their usage of The Changelog website, and their website access preferences. The Changelog visitors who do not wish to have cookies placed on their computers should set their browsers to refuse cookies before using The Changelog's websites, with the drawback that certain features of our website may not function properly without the aid of cookies.</p>
+
+<h3>Business Transfers</h3>
+
+<p>If The Changelog, or substantially all of its assets were acquired, or in the unlikely event that The Changelog goes out of business or enters bankruptcy, user information would be one of the assets that is transferred or acquired by a third party. You acknowledge that such transfers may occur, and that any acquirer of The Changelog may continue to use your personal information as set forth in this policy.</p>
+
+<h3>Ads and Sponsorships</h3>
+
+<p>Ads and Sponsorships appearing on The Changelog may be delivered to users by advertising partners, who may set cookies. These cookies allow the ad server to recognize your computer each time they send you an online advertisement to compile information about you or others who use your computer. This information allows ad networks to, among other things, deliver targeted advertisements that they believe will be of most interest to you. This Privacy Policy covers the use of cookies by The Changelog and does not cover the use of cookies by any advertisers.</p>
+
+<h3>Privacy Policy Changes</h3>
+
+<p>Although most changes are likely to be minor, we may change our Privacy Policy from time to time, and in our sole discretion. We encourage our visitors to <a href="https://github.com/thechangelog/legal">watch this repository on GitHub</a> to track changes to <a href="https://github.com/thechangelog/legal/blob/master/privacy.md">this document, our Privacy Policy</a>. Your continued use of this site after any change in this Privacy Policy will constitute your acceptance of such change.</p>
+        </div>
+    </div>
+</article>

--- a/web/templates/page/terms.html.eex
+++ b/web/templates/page/terms.html.eex
@@ -1,0 +1,308 @@
+<article class="section content">
+  <div class="container container--has-padding container--skinny">
+    <header class="content_header">
+      <h2>The Changelog Terms of Service</h2>
+    </header>
+    <div class="content_body">
+
+<p>Please read this document carefully before accessing or using The Changelog.</p>
+
+<h2>Introduction</h2>
+
+<h3>English, not Legalese.</h3>
+
+<p>Most Terms of Service and Privacy Policy documents are unreadable. They are written by and for lawyers, and in our opinion, they are not very effective.</p>
+
+<p>Because we believe in establishing long-term relationships with our readers and listeners, we decided to use plain English instead, to make our terms as clear as possible.</p>
+
+<p>Please don't forget that we are real people: take a look at our company page to get to know us a little. We're not perfect, but we're trying, and we genuinely care about you.</p>
+
+<p>When you read "The Changelog" or "we" as mentioned in this document, it refers to changelog.com (contact information), its affiliates and agents.</p>
+
+<p>Should you have other questions or concerns about this document, please get in touch <a href="http://thechangelog.com/contact/">using our contact form</a> or <a href="https://github.com/thechangelog/legal/issues/new">by submitting an issue on GitHub</a>.</p>
+
+<h3>About this document</h3>
+
+<p>This is a living document and is <a href="https://github.com/thechangelog/legal/blob/master/privacy.md">open source on GitHub</a>.</p>
+
+<p>If you read something in this this document and it rubs you the wrong way, or you feel something should be added, please <a href="https://github.com/thechangelog/legal/issues/new">submit an issue</a> or <a href="http://thechangelog.com/contact/">contact us</a>.</p>
+
+<p>We don't amend this document for any particular subscriber, but if your changes apply to all of our subscriber, we'll be happy to update it for everyone.</p>
+
+<p>We will likely improve this document over time. By continuing to use the site, you will implicitly accept the changes we make.</p>
+
+<p>Your access and use of The Changelog is always subject to the most current version of this document.</p>
+
+<p>This document was adapted from <a href="http://support.balsamiq.com/customer/portal/articles/174898">Balsamiq</a>.</p>
+
+<hr />
+
+<h2>Terms of Service</h2>
+
+<p>Using The Changelog means accepting these terms.</p>
+
+<p>By accessing, using, reading, or listening to The Changelog in any way, you agree to and are bound by the terms and conditions written in this document.</p>
+
+<p>If you do not agree to all of the terms and conditions contained in this document, do not access The Changelog.</p>
+
+<h3>Breach of Terms</h3>
+
+<p>If you breach any of the terms and conditions in this document, your authorization to access or use The Changelog automatically terminates. Any materials downloaded or printed from The Changelog in violation of the Terms of Use must be immediately destroyed.</p>
+
+<p>We may block, restrict, disable, suspend or terminate your access to all or part of The Changelog at any time in our sole discretion, without prior notice or liability to you. To this day, we have never had to do this, and we hope it never happens.</p>
+
+<p>If you think we removed your access by mistake, get in touch and we'll give you our reasoning. We also have the ability to restore access without losing any data.</p>
+
+<h3>Support</h3>
+
+<p>Support for The Changelog is provided by <a href="http://thechangelog.com/contact/">using our contact form</a>.</p>
+
+<h3>Access to your data</h3>
+
+<h4>What personal data do we collect and why?</h4>
+
+<p>We collect the following personal data:</p>
+
+<ul>
+<li>Name</li>
+<li>Email address</li>
+</ul>
+
+<p>We do not collect your address or credit card information directly. See the question "Who can see my credit card number?" below.</p>
+
+<p>We use return email addresses to answer the email we receive. Such addresses are not used for any other purpose and are not shared with outside parties.</p>
+
+<p>Please be aware that your browser must be enabled to accept cookies from changelog.com in order for you to use The Changelog.</p>
+
+<p>Finally, we never use or share the personally identifiable information provided to us online in ways unrelated to the ones described above.</p>
+
+<h4>Who can see my password?</h4>
+
+<p>No one. We never store your password unencrypted, so no one can read it.</p>
+
+<p>It is your sole responsibility to keep your user name, password and other sensitive information confidential. If you become aware of any unauthorized use of your account or any other breach of security, you shall notify The Changelog immediately.</p>
+
+<p>If you forget your password, we send you a secure link via email that lets you reset it.</p>
+
+<h4>Who can see my credit card number?</h4>
+
+<p>No one at The Changelog. We use the very trustworthy and secure Stripe payment service. Read <a href="https://stripe.com/us/terms">Stripe's Terms of Service</a> to learn more about their security measures. In short, they encrypt your credit card information.</p>
+
+<h4>Our commitment to children's privacy</h4>
+
+<p>Protecting the privacy of the very young is especially important. For that reason, we never collect or maintain information at our website from those we actually know are under 13, and no part of our website is structured to attract anyone under 13.</p>
+
+<h4>How can I access or correct my information?</h4>
+
+<p>You can access all your personally identifiable information that we collect online and maintain by logging in to The Changelog site you have access to and visiting the settings pages.</p>
+
+<h4>What are the guidelines The Changelog follows when accessing my data?</h4>
+
+<ul>
+<li>We restrict access to customer data to only senior members of The Changelog, and never to outside contractors</li>
+<li>We only do it in response to a customer support question</li>
+<li>We only do it in order to debug and fix the issue</li>
+<li>We never make changes to anything unless explicitly requested by a site owner</li>
+<li>We never ever ever share what we see with other customers or the general public</li>
+<li>We might give access to US authorities if requested in writing. We'll try not to, but we don't have the resources to fight the government.</li>
+</ul>
+
+<h4>How is my data protected from another customer's data?</h4>
+
+<p>All of our customers' data resides in the same database. We use software best practices to guarantee only people who you designate as viewers of your data can access it. In other words, we segment our customer data via software. We do our best and are very confident we're doing a good job at it, but, like every other web software that hosts customer data in the same database, we cannot guarantee a highly sophisticated hacker cannot access other people's data.</p>
+
+<h4>How are you protecting my data from hacker attacks?</h4>
+
+<p>All of our servers are highly physically secured at DigitalOcean's data centers. We also have our own practices in place, which follow the industry's best practices. We keep our servers always up to date with security fixes, have one-click ways to take down servers should they become infected/compromised and to create and deploy new clean ones.</p>
+
+<h4>What should I do if I find a security vulnerability in The Changelog?</h4>
+
+<p>If you have discovered a security concern, please contact us immediately <a href="http://thechangelog.com/contact/">using our contact form</a>. We'll work with you to make sure that we understand the scope of the issue, and that we fully address your concern. We consider correspondence sent through our contact form the highest priority, and work to address any issues that arise as quickly as possible.</p>
+
+<p>Please act in good faith towards our users' privacy and data during your disclosure. We won't take legal action against you or administrative action against your account if you act accordingly: White hat researchers are always appreciated.</p>
+
+<h3>Intellectual Property Rights</h3>
+
+<h4>Who owns The Changelog materials?</h4>
+
+<p>The Changelog materials are all the information, data, documents (e.g. white papers, press releases, datasheets, FAQs, etc.), communications, downloads, files, text, images, photographs, graphics, videos, webcasts, publications, content, tools, resources, software, code, programs and products on The Changelog produced by The Changelog.</p>
+
+<p>The Changelog materials are protected by copyrights, trademarks, patents, trade secrets and all other intellectual property and proprietary rights, and any unauthorized use of The Changelog Materials may violate such laws and the Terms of Use.</p>
+
+<p>You agree not to copy, republish, frame, download, transmit, modify, adapt, create derivative works based on, rent, lease, loan, sell, assign, distribute, display, perform, license, sublicense or reverse engineer The Changelog service or The Changelog Materials or any portions of them.</p>
+
+<p>You agree that you will not decompile, reverse engineer or otherwise attempt to discover the source code of the software. Any copying or redistribution of the software is prohibited, including any copying or reproduction of the software to any other server or location for further reproduction, redistribution or use on a service bureau basis. Any unauthorized use, copying or distribution of the software is expressly prohibited by law, and may result in severe civil and criminal penalties. Violators will be prosecuted to the maximum extent possible.</p>
+
+<p>The trademarks, logos and service marks displayed on this Site are the property of changelog.com or other third parties. You are not permitted to use them without the prior written consent of changelog.com or such third party that may own the Marks. The Changelog and The Changelog logo are trademarks of The Changelog, licensed to changelog.com.</p>
+
+<p>The Changelog materials may not be modified or altered in any way.</p>
+
+<p>The Changelog materials on The Changelog may not be distributed or sold, rented, leased, licensed or otherwise made available to others.</p>
+
+<p>You may not remove any copyright or other proprietary notices contained in The Changelog materials.</p>
+
+<p>You may not copy or distribute any graphics in The Changelog materials apart from their accompanying text.</p>
+
+<p>You will not quote or display The Changelog materials, or any portions thereof, out of context.</p>
+
+<p>The Changelog reserves the right to revoke the authorization to view, download and print The Changelog materials available via The Changelog at any time, and any such use shall be discontinued immediately upon notice from The Changelog.</p>
+
+<p>The rights granted to you constitute a license and not a transfer of title.</p>
+
+<p>Any The Changelog materials made available only upon payment of a fee may only be viewed, downloaded and printed subject to your payment of such fee.</p>
+
+<h3>Reliability</h3>
+
+<h4>Do you guarantee that The Changelog will be accessible at all times?</h4>
+
+<p>In short, we do not. Like all other cloud-based applications, we are vulnerable to the inherent unreliability of the Internet.</p>
+
+<p>We monitor The Changelog closely and have set up automated alerts to be notified when The Changelog service is under stress, so that we can deal with the issue before it becomes a problem that might impact customer access.</p>
+
+<p>You acknowledge and agree that The Changelog shall not be liable for any failure to store your materials on The Changelog at any time.</p>
+
+<h3>Play Nice Clauses</h3>
+
+<h4>Use of The Changelog</h4>
+
+<p>You agree that you shall not:</p>
+
+<ul>
+<li>Collect, harvest or engage in any other activity to obtain email addresses, phone numbers, personal information or any other information about others.</li>
+<li>Use or attempt to gain access to or use another's user or company account, password, data, or computer systems or networks connected to any The Changelog server, whether through hacking, password mining or any other means.</li>
+<li>Access or attempt to access any material that you are not authorized to access.</li>
+<li>Make available any files containing materials where you do not own or control, or have not received the necessary licenses to, all intellectual property rights, rights of privacy and publicity and all other rights in and to such materials.</li>
+<li>Use any materials in any manner that infringes any intellectual property rights or other rights of any party.</li>
+<li>Disrupt or interfere with the security of, or otherwise cause harm to, The Changelog service, The Changelog materials, systems resources, accounts, passwords, servers or networks connected to or accessible through The Changelog or any affiliated or linked sites.</li>
+<li>Transmit unsolicited or bulk communications to any The Changelog account holder or to any loomsdk.com or affiliated email address.</li>
+<li>Post or otherwise submit any software, programs or files that are harmful or disruptive of another's equipment, software or other property, including any corrupted files, time bombs, Trojan horses, viruses and worms.</li>
+<li>Create a false identity for the purpose of misleading others.</li>
+<li>Download any materials posted by another that you know, or reasonably should know, cannot be legally reproduced, distributed, performed or displayed in such manner.</li>
+<li>Disrupt, interfere or inhibit any other user from using and enjoying The Changelog service or other affiliated or linked sites, materials or services.</li>
+<li>Access or use The Changelog in any manner that could damage, disable, overburden or impair any The Changelog server or the network(s) connected to any The Changelog server.</li>
+<li>Violate any applicable laws or regulations related to the access to or use of The Changelog, or engage in any activity prohibited by the Terms of Use.</li>
+<li>Post or otherwise submit any topic, name, material or information that is child pornography, defamatory, excessively violent, harassing, inappropriate, indecent, lascivious, lewd, obscene, profane, racist, unlawful, or otherwise objectionable.</li>
+<li>Prepare, compile, use, download or otherwise copy any The Changelog user directory or other user or usage information or any portion thereof, or transmit, provide or otherwise distribute (whether or not for a fee) such directory or information to any third party.</li>
+<li>Engage in any chain letters, contests, junk email, pyramid schemes, spamming, surveys or any other duplicative or unsolicited messages (commercial or otherwise).</li>
+<li>Violate the rights of The Changelog or any third party (including rights of privacy and publicity) or abuse, defame, harass, stalk or threaten another.</li>
+<li>Use any The Changelog or The Changelog domain name as a pseudonymous return email address.</li>
+<li>Market any goods or services for any business purpose (including advertising and making offers to buy or sell goods or services), unless specifically allowed to do so by The Changelog.</li>
+</ul>
+
+<p>Materials and Services provided by third parties are governed by separate agreements accompanying such materials and services. The Changelog offers no guarantees and assumes no responsibility or liability of any type with respect to the third-party services, including any liability resulting from incompatibility between a third-party service, The Changelog materials, The Changelog service or another third-party service. You agree that you will not hold The Changelog responsible or liable with respect to the third-party services.</p>
+
+<h4>Special Treatment for Spammers</h4>
+
+<p>In the event of your or others' access to or use of The Changelog service in connection with the transmission of spam unsolicited email or postings in violation of these Terms of Use, you acknowledge and agree that The Changelog would be irreparably harmed thereunder and that monetary damages would be an insufficient and ineffective remedy; therefore you agree that The Changelog is entitled to obtain immediate injunctive relief against any such transmission (in addition to all other remedies available at law or in equity). The Changelog may without restriction block, filter or delete unsolicited email.</p>
+
+<h4>Restriction and Termination of Use</h4>
+
+<p>The Changelog may block, restrict, disable, suspend or terminate your access to all or part of The Changelog at any time in The Changelog's sole discretion, without prior notice or liability to you.</p>
+
+<h4>Notification of Copyright Infringement</h4>
+
+<p>The Changelog will, in appropriate circumstances, terminate the accounts of users who infringe the intellectual property rights of others. The Changelog will investigate notices of copyright infringement and take appropriate actions under the Digital Millennium Copyright Act, Title 17, United States Code, Section 512(c)(2) ("DMCA").</p>
+
+<p>If you believe that your work has been used or copied in a way that constitutes copyright infringement and such infringement is occurring on The Changelog or on sites linked to from The Changelog, please provide written notification of claimed copyright infringement to the designated agent for The Changelog (identified below), which must contain the following elements:</p>
+
+<ul>
+<li>A physical or electronic signature of the person authorized to act on behalf of the owner of the copyright interest that is alleged to have been infringed;</li>
+<li>A description of the copyrighted work or works that you claim have been infringed and identification of what content in such work(s) is claimed to be infringing and which you request to be removed or access to which is to be disabled;</li>
+<li>A description of where the content that you claim is infringing is located on The Changelog;</li>
+<li>Information sufficient to permit The Changelog to contact you, such as your physical address, telephone number, and email address;</li>
+<li>A statement by you that you have a good faith belief that the use of the content identified in your Notice in the manner complained of is not authorized by the copyright owner, its agent, ok the law;</li>
+<li>A statement by you that the information in your notice is accurate and, under penalty of perjury, that you are the copyright owner or authorized to act on the copyright owner's behalf.</li>
+</ul>
+
+<h4>Links to Third Party Sites</h4>
+
+<p>The Changelog may include links that will take you to other sites outside of The Changelog service. The linked sites are provided by The Changelog to you as a convenience and the inclusion of the links do not imply any endorsement by The Changelog of any linked site. The Changelog has no control of the linked sites and you therefore acknowledge and agree that The Changelog is not responsible for the contents of any linked site, any link contained in a linked site or any changes or updates to a linked site. You further acknowledge and agree that The Changelog is not responsible for any form of transmission (e.g. webcasting) received from any linked site.</p>
+
+<h4>Advertisements and Promotions</h4>
+
+<p>The Changelog may run advertisements and promotions from third parties via The Changelog in any manner or mode and to any extent. Your communications, activities, relationships and business dealings with any third parties advertising or promoting via The Changelog, including payment and delivery of related goods or services, and any other terms, conditions, warranties or representations associated with such dealings, shall be solely matters between you and such third parties. You acknowledge and agree that The Changelog is not responsible or liable for any loss or damage of any kind incurred as the result of any such dealings or as the result of the presence of such non-The Changelog advertisers on The Changelog.</p>
+
+<h4>Warranties and Disclaimers</h4>
+
+<p>The Changelog service and The Changelog materials are provided by The Changelog under these terms of use "as is" without warranty of any kind, either express, implied, statutory or otherwise, including, but not limited to, the implied warranties of title, non-infringement, merchantability or fitness for a particular purpose. Without limiting the foregoing, The Changelog makes no warranty that:</p>
+
+<ol>
+<li>The Changelog service and The Changelog materials will meet your requirements;</li>
+<li>The Changelog service and The Changelog materials will be uninterrupted, timely, secure, or error-free;</li>
+<li>the results that may be obtained from the use of The Changelog service and The Changelog materials will be effective, accurate, or reliable;</li>
+<li>the quality of the site or any services or materials purchased or accessible by you will meet your expectations; and</li>
+<li>any errors or defects in The Changelog service and The Changelog materials will be corrected.</li>
+</ol>
+
+<p>This The Changelog service and The Changelog materials may include technical or other mistakes, inaccuracies, or typographical errors. The Changelog may make changes to the site, materials and services, including the prices and descriptions of any software or products listed, at any time in its sole discretion and without notice. The Changelog service and The Changelog materials may be out of date, and The Changelog makes no commitment to update the site, materials and services.</p>
+
+<p>You acknowledge and agree that:</p>
+
+<ol>
+<li>The Changelog does not control, endorse, or accept responsibility for any materials or services offered by third parties, including third-party vendors and third parties accessible through linked sites;</li>
+<li>The Changelog makes no representations or warranties whatsoever about any such third parties, their materials or services;</li>
+<li>any dealings you may have with such third parties are at your own risk; and</li>
+<li>The Changelog shall not be liable or responsible for any materials or services offered by third parties.</li>
+</ol>
+
+<p>The Changelog does not control or endorse the materials found in any services and specifically disclaims any liability with regard to the site, services and any actions resulting from your use of The Changelog service and The Changelog materials and participation in any services. Managers, hosts, project members and other third parties are not authorized The Changelog spokespersons, and their views do not necessarily reflect those of The Changelog. To the maximum extent permitted by law, The Changelog will have no liability related to user materials arising under intellectual property rights, libel, privacy, publicity, obscenity or other laws. The Changelog also disclaims all liability with respect to the misuse, loss, modification or unavailability of any user materials.</p>
+
+<p>The use of The Changelog service, The Changelog materials or the downloading or other use of any materials is done at your own discretion and risk and with your agreement that you will be solely responsible for any damage to your computer system, loss of data or other harm that results from such activities. The Changelog assumes no liability for any computer virus or other similar software code that is downloaded to your computer from the site or in connection with any services or materials. No advice or information, whether oral or written, obtained by you from The Changelog or via the site, services or materials shall create any warranty not expressly stated in the terms of use. The Changelog will not be liable for any loss that you may incur as a result of someone else using your password or account with respect to the site or any services or materials, either with or without your knowledge.</p>
+
+<p>Some states or jurisdictions do not allow the exclusion of implied warranties or limitations on how long an implied warranty may last, so the above limitations may not apply to you. To the extent permissible, any implied warranties are limited to ninety (90) days.</p>
+
+<h4>Indemnity and Liability</h4>
+
+<p>You agree to indemnify and hold The Changelog and its officers, co-branders, other partners and employees harmless from any claim or demand, including reasonable attorneys' fees, made by any third party due to or arising out of:</p>
+
+<ol>
+<li>your user materials and any other content (e.g. computer viruses) that you may submit, post to or transmit through The Changelog, including a third party's use of such user materials or content (e.g. reliance on the accuracy, completeness or usefulness of your user materials);</li>
+<li>your access to or use of The Changelog (including any use by your employees, contractors or agents and all uses of your account numbers, user names and passwords, whether or not actually or expressly authorized by you, in connection with The Changelog);</li>
+<li>your connection to The Changelog;</li>
+<li>your violation of the Terms of Use;</li>
+<li>the actions of any member of your work group, including non-logged in users you have granted access to your The Changelog site;</li>
+<li>your infringement of any third party's intellectual property rights when using any of the software made available on The Changelog;</li>
+<li>your violation of any rights of any third party;</li>
+<li>your access to or use of linked sites and your connections thereto; or</li>
+<li>any dealings between you and any third parties advertising or promoting via The Changelog.</li>
+</ol>
+
+<h4>International Users</h4>
+
+<p>The Changelog service can be accessed from countries around the world and may contain references to The Changelog products, services and programs that are not available in your country. These references do not imply that The Changelog intends to announce such products, services or programs in your country. The Site is controlled, operated and administered by changelog.com and its affiliates from their offices within the United States of America and Italy. The Changelog makes no representation that The Changelog service and The Changelog materials are appropriate or available for use at other locations outside the United States, and access to the Site from territories where the Site, the Services or Materials are illegal is prohibited. If you access the Site from a location outside the United States, you are responsible for compliance with all local laws.</p>
+
+<p>The export and re-export of The Changelog Software are controlled by the United States Export Administration Regulations, and such Software may not be exported or re-exported to Cuba, Iran, Libya, North Korea, Sudan, Syria, or any country to which the United States embargoes goods. In addition, the Software may not be distributed to persons on the Table of Denial Orders, the Entity List, or the List of Specially Designated Nationals.</p>
+
+<p>By downloading Software, you are certifying that you are not a national of Cuba, Iran, Libya, North Korea, Sudan, Syria or any country to which the United States embargoes goods, and that you are not a person on the Table of Denial Orders, the Entity List, or the List of Specially Designated Nationals.</p>
+
+<p>All The Changelog Software, products and publications are commercial in nature. The Software and documentation available on this Site are "Commercial Items," as that term is defined at 48 C.F.R. §2.101, consisting of "Commercial Computer Software" and "Commercial Computer Software Documentation," as such terms are used in 48 C.F.R. §12.212 or 48 C.F.R. §227.7202, as applicable. Consistent with 48 C.F.R. §12.212 or 48 C.F.R. §§227.7202-1 through 227.7202-4, as applicable, the Commercial Computer Software and Commercial Computer Software Documentation are licensed to U.S. Government end users (A) only as Commercial Items and (B) with only those rights as are granted to all other users pursuant to the Terms of Use and the applicable license agreement.</p>
+
+<h4>Limitation of Liability</h4>
+
+<p>In no event shall The Changelog, its officers, directors, employees, partners or suppliers be liable to you or any third party for any special, punitive, incidental, indirect or consequential damages or losses of any kind, or any damages or losses whatsoever, including those resulting from loss of use, data or profits, whether or not foreseeable or if The Changelog has been advised of the possibility of such damages or losses, and on any theory of liability, including breach of contract or warranty, negligence or other tortious action, or any other claim arising out of or in connection with:</p>
+
+<ol>
+<li>the access or use of or the inability to access or use The Changelog service or The Changelog materials;</li>
+<li>the statements or actions of any third party on or via the site, services or materials;</li>
+<li>any dealings with vendors or other third parties;</li>
+<li>any unauthorized access to or alteration of your transmissions, user materials or other data;</li>
+<li>any information that is sent or received or not sent or received;</li>
+<li>any failure to store or loss of data, files, materials or other content;</li>
+<li>any services available that are delayed or interrupted;</li>
+<li>any web site referenced or linked to from this site; or</li>
+<li>your access to or use of or inability to access or use any linked site.</li>
+</ol>
+
+<p>Some jurisdictions prohibit the exclusion or limitation of liability for consequential or incidental damages. Accordingly, the limitations and exclusions set forth above may not apply to you.</p>
+
+<h3>Governing Law and Jurisdiction</h3>
+
+<p>The Changelog service (excluding linked sites) is controlled by changelog.com from its offices within the state of Texas, United States of America. By accessing The Changelog, you agree that all matters relating to your access to, or use of, The Changelog shall be governed by the statutes and laws of the State of Washington, without regard to the conflicts of laws principles thereof. The parties specifically disclaim the U.N. Convention on Contracts for the International Sale of Goods. You also agree and hereby submit to the exclusive personal jurisdiction and venue of the Harris County Courthouse and the United States District Court for the state of Texas with respect to such matters.</p>
+
+<h3>General</h3>
+
+<p>The Terms of Use and other rules, guidelines, licenses and disclaimers posted via The Changelog or in connection with the Materials and Services constitute the entire agreement between The Changelog and you with respect to your access to or use of The Changelog service and materials superseding any prior agreements between you and The Changelog on such subject matter (including any prior versions of the Terms of Use). Notwithstanding the foregoing, to the extent that any terms set forth in the Terms of Use expressly contradict any terms of a written agreement between you and The Changelog regarding the use of specific Services or Materials (including Service-specific terms of use and Software-specific licenses) ("Executed Agreement"), such contradictory terms set forth in the Executed Agreement shall govern. You may also be subject to additional terms and conditions that may apply when you use other The Changelog services, third party content or third party software. You may not assign or otherwise transfer the Terms of Use nor any right granted hereunder without The Changelog's prior written consent. If for any reason a court of competent jurisdiction finds any provision of the Terms of Use, or portion thereof, to be unenforceable, that provision shall be enforced to the maximum extent permissible so as to effect the intent of the parties as reflected by that provision, and the remainder of the Terms of Use shall continue in full force and effect. Any failure by The Changelog to enforce or exercise any provision of the Terms of Use or related right shall not constitute a waiver of that right or provision. The section titles used in the Terms of Use are purely for convenience and carry with them no legal or contractual effect.</p>
+
+        </div>
+    </div>
+</article>


### PR DESCRIPTION
Ref #112

- Add script to generated from markdown to html
- add the final adjusted html templates
- add two routes which are `terms` and `privacy`