### PR TITLE
Support faster playback

### DIFF
--- a/web/static/app/components/audio.js
+++ b/web/static/app/components/audio.js
@@ -94,6 +94,15 @@ export default class ChangelogAudio {
     this.audio.currentTime = to;
   }
 
+  changeSpeed() {
+    if (this.audio.playbackRate === 2) {
+      this.audio.playbackRate = 1;
+      return;
+    }
+
+    this.audio.playbackRate += 0.5;
+  }
+
   runOnce(eventName, fn) {
     let listener = () => {
       fn.call();

--- a/web/static/app/components/onsite_player.js
+++ b/web/static/app/components/onsite_player.js
@@ -61,6 +61,11 @@ export default class OnsitePlayer {
         event.preventDefault();
         this.togglePlayPause();
       }
+
+      // 83 == s
+      if (event.keyCode == 83 && !u(event.target).is("input, textarea")) {
+        this.changeSpeed();
+      }
     });
   }
 
@@ -93,6 +98,10 @@ export default class OnsitePlayer {
     } else {
       this.play();
     }
+  }
+
+  changeSpeed() {
+    this.audio.changeSpeed();
   }
 
   seekBy(to) {


### PR DESCRIPTION
Adds a keyboard shortcut ("s") that toggles playback speed.

Each keypress speeds up the audio by 0.5x, wrapping back to 1x when the
speed is 2x.

Closes #139.