### PR TITLE
Playbar now matches player state

### DIFF
--- a/web/static/app/app.js
+++ b/web/static/app/app.js
@@ -19,7 +19,12 @@ u(document).on("click", "[data-play]", function(event) {
   if (player.canPlay()) {
     event.preventDefault();
     const clicked = u(event.target).closest("a, button");
-    player.load(clicked.attr("href"), clicked.data("play"));
+    if(player.currentlyLoaded === clicked.data("play")) {
+      player.togglePlayPause();
+    } else {
+      player.load(clicked.attr("href"), clicked.data("play"));
+    }
+
   }
 });
 

--- a/web/static/app/components/onsite_player.js
+++ b/web/static/app/components/onsite_player.js
@@ -2,6 +2,7 @@ import { u, ajax } from "umbrellajs";
 import Episode from "components/episode";
 import Log from "components/log";
 import ChangelogAudio from "components/audio";
+import Playbar from "components/playbar";
 
 export default class OnsitePlayer {
   constructor(selector) {
@@ -10,6 +11,8 @@ export default class OnsitePlayer {
       this.audio = new ChangelogAudio();
       this.detailsLoaded = false;
       this.audioLoaded = false;
+      this.playbar = new Playbar();
+      this.currentlyLoaded = "";
       this.attachUI(selector);
       this.attachEvents();
       this.attachKeyboardShortcuts();
@@ -84,11 +87,13 @@ export default class OnsitePlayer {
   play() {
     requestAnimationFrame(this.step.bind(this));
     this.audio.play();
+    this.playbar.play();
     this.playButton.addClass("is-playing").removeClass("is-paused is-loading");
   }
 
   pause() {
     this.audio.pause();
+    this.playbar.pause();
     this.playButton.addClass("is-paused").removeClass("is-playing is-loading");
   }
 
@@ -113,6 +118,9 @@ export default class OnsitePlayer {
   load(audioUrl, detailsUrl) {
     this.resetUI();
     this.playButton.addClass("is-loading");
+    this.playButton.attr('data-loaded', detailsUrl);
+    this.currentlyLoaded = detailsUrl;
+    this.playbar.belongsTo(this.currentlyLoaded);
     this.loadAudio(audioUrl);
     this.loadDetails(detailsUrl);
   }
@@ -170,6 +178,7 @@ export default class OnsitePlayer {
     this.title.text("");
     this.current.text("0:00");
     this.duration.text("0:00");
+    this.playButton.first().removeAttribute("data-loaded");
     this.resetPrevUI();
     this.resetNextUI();
     this.scrubber.first().value = 0;

--- a/web/static/app/components/playbar.js
+++ b/web/static/app/components/playbar.js
@@ -1,0 +1,40 @@
+import { u } from "umbrellajs";
+
+export default class Playbar {
+  constructor() {
+    this.isPlaying = false;
+    this.owner = '';
+    u(document).on("turbolinks:load", () => {
+      this.isPlaying && this.owner && this.exists() && this.setUI();
+    });
+  }
+
+  exists() {
+    return !!(u(`a[data-play="${this.owner}"]`).length);
+  }
+
+  pause() {
+    this.isPlaying = false;
+    this.resetUI();
+  }
+
+  play() {
+    this.isPlaying = true;
+    this.setUI();
+  }
+
+  resetUI() {
+    if(u(`a[data-play="${this.owner}"]`).hasClass("playbar_pause")) {
+      u(`a[data-play="${this.owner}"]`).removeClass("playbar_pause").addClass("playbar_play").text("Play");
+    }
+  }
+
+  setUI() {
+    u(`a[data-play="${this.owner}"]`).text("Pause").removeClass("playbar_play").addClass("playbar_pause");
+  }
+
+  belongsTo(subject) {
+    this.resetUI();
+    this.owner = subject;
+  }
+}

--- a/web/static/app/modules/_modules.sass
+++ b/web/static/app/modules/_modules.sass
@@ -27,6 +27,7 @@
 @import news-list
 @import news-item
 @import pagination
+@import playbar
 @import podcast-header
 @import podcast-summary
 @import podcast-summary-widget

--- a/web/static/app/modules/_playbar.sass
+++ b/web/static/app/modules/_playbar.sass
@@ -1,0 +1,5 @@
+.playbar_play
+    background-image: url("/images/icon-play.svg");
+.playbar_pause
+    background-image: url("/images/pause.svg");
+    background-size: 11px 20px !important;

--- a/web/templates/episode/_play_bar.html.eex
+++ b/web/templates/episode/_play_bar.html.eex
@@ -6,8 +6,7 @@
           to: audio_url(@episode),
           data: [play: episode_path(@conn, :play, @episode.podcast.slug, @episode.slug)],
           role: "button",
-          class: "toolbar_item toolbar_item--button",
-          style: "background-image: url('#{static_url(@conn, "/images/icon-play.svg")}')" %>
+          class: "toolbar_item toolbar_item--button playbar playbar_play" %>
     <% end %>
 
     <%= link "Subscribe",

--- a/web/templates/podcast/_episode_summary.html.eex
+++ b/web/templates/podcast/_episode_summary.html.eex
@@ -28,8 +28,7 @@
           to: EpisodeView.audio_url(@episode),
           data: [play: episode_path(@conn, :play, @episode.podcast.slug, @episode.slug)],
           role: "button",
-          class: "toolbar_item toolbar_item--button",
-          style: "background-image: url('#{static_url(@conn, "/images/icon-play.svg")}')" %>
+          class: "toolbar_item toolbar_item--button playbar playbar_play" %>
 
       <%= link "Details",
           title: "Episode Details",


### PR DESCRIPTION
Found Thechangelog podcast today and listened to multiple casts today gotta say I was really vibing with it. Although while using the site I kept running into an issue where I kept hitting the play button on the playbar instead of the bottom player which auto restarted any podcast instead of resuming it if it was paused, super annoying when you have no idea what timestamp you were on during a 2 hour podcast.

With this pull request the play bars are now in sync with the bottom player and properly play and pause <3

ps. shout out to Guillermo Rauch. 

Before: 
![2016-12-12 02 57 42](https://cloud.githubusercontent.com/assets/20787123/21096923/df3d204a-c016-11e6-8846-fc14314e0662.gif)


After: (sorry for external link gif to big to upload on here)

https://gfycat.com/InstructiveImpossibleHalibut