### PR TITLE
add semicolon after return statement

### DIFF
--- a/web/static/app/components/audio.js
+++ b/web/static/app/components/audio.js
@@ -2,7 +2,7 @@ export default class ChangelogAudio {
   constructor() {
     if (typeof Audio === "undefined") {
       this.hasAudio = false;
-      return
+      return;
     } else {
       this.hasAudio = true;
     }


### PR DESCRIPTION
add a semicolon after the `return` statement.