### PR TITLE
Remove duplicate sign in link in welcome email

### DIFF
--- a/web/templates/email/sign_in.html.eex
+++ b/web/templates/email/sign_in.html.eex
@@ -6,8 +6,6 @@
 
     <%= link "Sign in to Changelog", to: AuthView.auth_url(Endpoint, @person), class: "btn-primary", itemprop: "url" %>
 
-    <%= link "Sign in to Changelog", to: AuthView.auth_url(Endpoint, @person), class: "btn-primary", itemprop: "url" %>
-
     <p><em>This link will self-destruct in <%= auth_link_expires_in(@person) %>.</em><p>
     <p>Already expired? <em><%= link "Request a new link.", to: sign_in_url(Endpoint, :new) %></em></p>
   </td>


### PR DESCRIPTION
There are two buttons in the sign in email:

<img width="667" alt="screen shot 2017-03-26 at 16 51 13" src="https://cloud.githubusercontent.com/assets/898057/24332295/8321a94a-1244-11e7-8c3b-41a368b8c836.png">

<img width="755" alt="screen shot 2017-03-26 at 16 51 58" src="https://cloud.githubusercontent.com/assets/898057/24332300/8ef1eb0e-1244-11e7-9065-ee4e2d4196db.png">

By the way, Gmail would really like inlining of styles… 😉 