### PR TITLE
Fixed binary_to_term vulnerability by using binary_to_term/2

### DIFF
--- a/lib/changelog_web/plugs/conn.ex
+++ b/lib/changelog_web/plugs/conn.ex
@@ -25,7 +25,7 @@ defmodule ChangelogWeb.Plug.Conn do
           generate(conn, @signing_salt, key_opts()),
           generate(conn, @encryption_salt, key_opts()))
 
-        :erlang.binary_to_term(decrypted)
+        :erlang.binary_to_term(decrypted, [safe])
     end
   end
 

--- a/lib/changelog_web/plugs/conn.ex
+++ b/lib/changelog_web/plugs/conn.ex
@@ -25,7 +25,7 @@ defmodule ChangelogWeb.Plug.Conn do
           generate(conn, @signing_salt, key_opts()),
           generate(conn, @encryption_salt, key_opts()))
 
-        :erlang.binary_to_term(decrypted, [safe])
+        :erlang.binary_to_term(decrypted, [:safe])
     end
   end
 


### PR DESCRIPTION
If you take a look at the put|get_encrypted_cookie defs  they seem to make unsafe usage of binary_to_term. Binary_to_term/2 lets you unserialise data the same way as binary_to_term/1 does. The big difference is that the second argument is an option list. If you pass in [safe], the binary won’t be decoded if it contains unknown atoms or anonymous functions, which could exhaust the memory of a node or represent a security risk. Use binary_to_term/2 rather than binary_to_term/1 if you’re decoding data that could be unsafe. 

Kind Regards,

Jordy