### PR TITLE
Extract auth_link_expires_in out to public helpers, reference in sign in

### DIFF
--- a/lib/changelog_web/helpers/public_helpers.ex
+++ b/lib/changelog_web/helpers/public_helpers.ex
@@ -69,4 +69,9 @@ defmodule ChangelogWeb.Helpers.PublicHelpers do
   def with_timestamp_links(string) do
     String.replace(string, Regexp.timestamp, ~S{<a class="timestamp" href="#t=\0">\0</a>})
   end
+
+  def auth_link_expires_in(person) do
+    diff = Timex.diff(person.auth_token_expires_at, Timex.now, :duration)
+    Timex.format_duration(diff, :humanized)
+  end
 end

--- a/lib/changelog_web/templates/auth/new.html.eex
+++ b/lib/changelog_web/templates/auth/new.html.eex
@@ -2,7 +2,7 @@
   <h1 class="auth-header">Sign In</h1>
 
   <%= if @person do %>
-    <div class="form_submit_response form_submit_response--success"><p>Check your email! We sent you a single-use sign in link. It will expire in 15 minutes.</p></div>
+    <div class="form_submit_response form_submit_response--success"><p>Check your email! We sent you a single-use sign in link. It will expire in <%= auth_link_expires_in(@person) %>.</p></div>
     <%= if Mix.env == :dev do %>
       <p>Psst! Since you're hacking we'll just skip the email process. <%= link "click here", to: auth_path(@conn, @person), data: [turbolinks: false] %> instead!</p>
     <% end %>

--- a/lib/changelog_web/views/email_view.ex
+++ b/lib/changelog_web/views/email_view.ex
@@ -4,11 +4,6 @@ defmodule ChangelogWeb.EmailView do
   alias Changelog.Faker
   alias ChangelogWeb.{AuthView, Endpoint, NewsItemView, PersonView}
 
-  def auth_link_expires_in(person) do
-    diff = Timex.diff(person.auth_token_expires_at, Timex.now, :duration)
-    Timex.format_duration(diff, :humanized)
-  end
-
   def greeting(person) do
     label = if Enum.member?(Faker.names, person.name) do
       "there"


### PR DESCRIPTION
I've moved the `auth_link_expires_in/1` over to public helpers so that the same expiration time can be reported on sign-in and in the sign-in email.

See: #212 