### PR TITLE
Convert excerpt blockquotes to ems

### DIFF
--- a/lib/changelog_web/helpers/shared_helpers.ex
+++ b/lib/changelog_web/helpers/shared_helpers.ex
@@ -1,6 +1,7 @@
 defmodule ChangelogWeb.Helpers.SharedHelpers do
   use Phoenix.HTML
 
+  alias HtmlSanitizeEx.Scrubber
   alias Changelog.Regexp
   alias Phoenix.{Controller, Naming}
 
@@ -79,9 +80,24 @@ defmodule ChangelogWeb.Helpers.SharedHelpers do
   def md_to_text(md) when is_binary(md), do: md |> md_to_html |> HtmlSanitizeEx.strip_tags |> sans_new_lines
   def md_to_text(md) when is_nil(md), do: ""
 
+  def md_to_oneline(md) when is_binary(md) do
+    md
+    |> md_to_html
+    |> Scrubber.scrub(ChangelogWeb.Helpers.StripBlockTags)
+    |> blockquote_to_em
+    |> sans_new_lines
+  end
+  def md_to_oneline(md) when is_nil(md), do: ""
+
   def sans_p_tags(html), do: String.replace(html, Regexp.tag("p"), "")
 
   def sans_new_lines(string), do: String.replace(string, "\n", " ")
+
+  def blockquote_to_em(string) do
+    string
+    |> String.replace("<blockquote>", "<em>")
+    |> String.replace("</blockquote>", "</em>")
+  end
 
   def is_future?(time = %DateTime{}, as_of \\ Timex.now), do: Timex.compare(time, as_of) == 1
   def is_past?(time = %DateTime{}, as_of \\ Timex.now), do: Timex.compare(time, as_of) == -1

--- a/lib/changelog_web/helpers/strip_block_tags.ex
+++ b/lib/changelog_web/helpers/strip_block_tags.ex
@@ -1,0 +1,14 @@
+defmodule ChangelogWeb.Helpers.StripBlockTags do
+  require HtmlSanitizeEx.Scrubber.Meta
+  alias HtmlSanitizeEx.Scrubber.Meta
+
+  Meta.remove_cdata_sections_before_scrub()
+  Meta.strip_comments()
+  Meta.allow_tag_with_these_attributes("b", [])
+  Meta.allow_tag_with_these_attributes("blockquote", [])
+  Meta.allow_tag_with_these_attributes("del", [])
+  Meta.allow_tag_with_these_attributes("em", [])
+  Meta.allow_tag_with_these_attributes("i", [])
+
+  Meta.strip_everything_not_covered()
+end

--- a/lib/changelog_web/templates/news_item/_summary.html.eex
+++ b/lib/changelog_web/templates/news_item/_summary.html.eex
@@ -2,7 +2,7 @@
   <%= render("_header.html", assigns) %>
 <%= if @item.story do %>
   <div class="news_item-description">
-    <p><%= @item.story |> md_to_text %></p>
+    <p><%= @item.story |> md_to_oneline |> raw %></p>
     <%= link to: permalink_path(@conn, @item), class: "news_item-description-continue", data: permalink_data(@item) do %>
       <span>read more...</span>
     <% end %>


### PR DESCRIPTION
This ain’t pretty. Someone else could do a much better job at this. The general idea is that we want to strip all block-level elements from excerpts and convert _some_ of them to inline elements.