### PR TITLE
fixes #251 shows the player once the audio has begun if it was previously inactive

### DIFF
--- a/assets/app/modules/onsitePlayer.js
+++ b/assets/app/modules/onsitePlayer.js
@@ -107,6 +107,7 @@ export default class OnsitePlayer {
   playUI() {
     this.playButtons.play();
     this.playButton.addClass("is-playing").removeClass("is-paused is-loading");
+    if (!this.isActive()) this.show();
   }
 
   pause() {


### PR DESCRIPTION
Playing audio after dismissing the player with the escape key shortcut now behaves the same whether playing the same episode or a new one.