### PR TITLE
avoid shell for pathname expansion

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -42,6 +42,6 @@
     "compile": "webpack --mode=production -p",
     "add": "all-contributors add",
     "generate": "all-contributors generate",
-    "test": "mocha --require @babel/register test/**/*.js"
+    "test": "mocha --require @babel/register \"test/**/*.js\""
   }
 }


### PR DESCRIPTION
This effectively delegates pathname expansion to the [glob](https://npm.im) module,
because cross-platform.

* * *

I sent this PR because I am fussy.  Yes, it's unlikely someone would try to run this on a Windows command prompt, but *if they did*, this would *not* make their day worse.