### PR TITLE
Add make target for building & publishing runtime image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     parallelism: 1
     docker:
-      - image: thechangelog/runtime:elixir1.6.5-ffmpeg
+      - image: thechangelog/runtime
         environment:
           MIX_ENV: test
       - image: circleci/postgres:9.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
-FROM circleci/elixir:1.6-node
-
-USER root
-
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update \
-    && apt-get install -y ffmpeg \
-    && which ffmpeg \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mix do local.rebar --force, local.hex --force
+FROM thechangelog/runtime
 
 RUN mkdir /app
 COPY . /app

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,11 @@
+FROM circleci/elixir:1.6-node
+
+USER root
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y ffmpeg \
+    && which ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mix do local.rebar --force, local.hex --force

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,14 @@ proxy: $(DOCKER) ## Builds & publishes thechangelog/proxy image
 	$(DOCKER) tag thechangelog/proxy:$$BUILD_VERSION thechangelog/proxy:latest && \
 	$(DOCKER) push thechangelog/proxy:latest
 
+.PHONY: runtime
+runtime: $(DOCKER) ## Builds & publishes changelog.com runtime as a Docker image
+	@BUILD_VERSION=$$(date -u +'%Y-%m-%d.%H%M%S') ; \
+	$(DOCKER) build --tag thechangelog/runtime:$$BUILD_VERSION --file Dockerfile.runtime . && \
+	$(DOCKER) push thechangelog/runtime:$$BUILD_VERSION && \
+	$(DOCKER) tag thechangelog/runtime:$$BUILD_VERSION thechangelog/runtime:latest && \
+	$(DOCKER) push thechangelog/runtime:latest
+
 .PHONY: md
 md: $(DOCKER) ## Preview Markdown locally, as it will appear on GitHub
 	@$(DOCKER) run --interactive --tty --rm --name changelog_md \


### PR DESCRIPTION
Merge this before #258 

This is something that the Concourse does via the [`build-runtime` job](https://ci.changelog.com/teams/main/pipelines/changelog.com/jobs/build-runtime/builds/4). Since we want to replace Concourse with CircleCI, we'll need to be able to do this locally, with a single command.

The initial Dockerfile was stored in [infrastructure/roles/dotcom/files/docker/runtime/Dockerfile](https://github.com/thechangelog/infrastructure/blob/deef8db2f92becdcb796096d7077d683dd5ba3cb/roles/dotcom/files/docker/runtime/Dockerfile)
and in [changelog.com/Dockerfile](https://github.com/thechangelog/changelog.com/blob/0611abb43f83792b7ff9e60ded0094ec0d6d5395/Dockerfile) since [#246](https://github.com/thechangelog/changelog.com/pull/246). As of this story, `changelog.com/Dockerfile` will be split into multiple files: `Dockerfile.runtime` & `Dockerfile` which will build on `thechangelog/runtime`, an artefact of `Dockerfile.runtime`.

`thechangelog/runtime` image is used by [CircleCI for running tests](https://circleci.com/gh/thechangelog/changelog.com/240#tests/containers/0) (see the **Spin up Environment** output), and by docker-compose when [running the app locally](https://github.com/thechangelog/changelog.com/blob/aa95d83f4dec757b2a7e0cc086253e16065bf8db/Makefile#L88-L95).

For the record, `Dockerfile.runtime` is the place where Elixir & Erlang used by changelog.com are updated. Elixir & Erlang versions are determined by `FROM circleci/elixir:1.6-node`. Since this image also includes **node.js**, we also pick up Yarn & others for asset compilation & digestion. The best part is that this image is maintained by CircleCI, so we will pick up any updates CircleCI does to this image by re-building it. Learn more about [Pre-Build CircleCI Docker Images](https://circleci.com/docs/2.0/circleci-images/).