### PR TITLE
Run tests as circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     parallelism: 1
     docker:
-      - image: thechangelog/runtime:elixir1.6.5-ffmpeg
+      - image: thechangelog/runtime
         environment:
           MIX_ENV: test
       - image: circleci/postgres:9.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
-FROM circleci/elixir:1.6-node
-
-USER root
-
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update \
-    && apt-get install -y ffmpeg \
-    && which ffmpeg \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mix do local.rebar --force, local.hex --force
+FROM thechangelog/runtime
 
 RUN mkdir /app
 COPY . /app

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,11 @@
+FROM circleci/elixir:1.6-node
+
+USER root
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y ffmpeg \
+    && which ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mix do local.rebar --force, local.hex --force

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,14 @@ proxy: $(DOCKER) ## Builds & publishes thechangelog/proxy image
 	$(DOCKER) tag thechangelog/proxy:$$BUILD_VERSION thechangelog/proxy:latest && \
 	$(DOCKER) push thechangelog/proxy:latest
 
+.PHONY: runtime
+runtime: $(DOCKER) ## Builds & publishes changelog.com runtime as a Docker image
+	@BUILD_VERSION=$$(date -u +'%Y-%m-%d.%H%M%S') ; \
+	$(DOCKER) build --tag thechangelog/runtime:$$BUILD_VERSION --file Dockerfile.runtime . && \
+	$(DOCKER) push thechangelog/runtime:$$BUILD_VERSION && \
+	$(DOCKER) tag thechangelog/runtime:$$BUILD_VERSION thechangelog/runtime:latest && \
+	$(DOCKER) push thechangelog/runtime:latest
+
 .PHONY: md
 md: $(DOCKER) ## Preview Markdown locally, as it will appear on GitHub
 	@$(DOCKER) run --interactive --tty --rm --name changelog_md \

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ runtime: $(DOCKER) ## Builds & publishes changelog.com runtime as a Docker image
 	$(DOCKER) tag thechangelog/runtime:$$BUILD_VERSION thechangelog/runtime:latest && \
 	$(DOCKER) push thechangelog/runtime:latest
 
+.PHONY: test
+test: $(COMPOSE) ## Runs tests as they run on CircleCI
+	@$(COMPOSE) run --rm -e MIX_ENV=test -e DB_URL=ecto://postgres@db:5432/changelog_test app mix test
+
 .PHONY: md
 md: $(DOCKER) ## Preview Markdown locally, as it will appear on GitHub
 	@$(DOCKER) run --interactive --tty --rm --name changelog_md \

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,9 +17,7 @@ config :changelog, Changelog.Mailer,
 config :changelog, Changelog.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox,
-  database: "changelog_test",
-  username: "postgres",
-  password: "postgres"
+  url: (System.get_env("DB_URL") || "ecto://postgres:postgres@localhost:5432/changelog_test")
 
 config :arc,
   storage_dir: "priv/uploads"


### PR DESCRIPTION
This should be merged after #257 

CircleCI runs tests in a container, based on thechangelog/runtime image, and uses the circleci/postgres:9.6 image for the db container. We need to be able to do the same locally so that if CircleCI is not available (regardless of the reason), changelog.com can carry on. Yes, things will be more inconvenient (no auto-triggers), but the world won't stop for changelog.com if CircleCI goes on holiday.

The end-goal is to be able to push changelog.com updates from local, old skool style. To be at ease with this approach, we must be able to go through the same process as CircleCI, including running tests.
