### PR TITLE
WIP: Upgrade PostgreSQL to v11.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ docker
 import
 nginx
 priv/db
+priv/db11
 priv/uploads
 script
 terraform

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ npm-debug.log*
 /config/prod.secret.exs
 /priv/uploads
 /priv/db
+/priv/db11
 /import/cookies.yml
 /cover
 

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ prevent-incompatible-deps-reaching-the-docker-image:
 
 .PHONY: create-dirs-mounted-as-volumes
 create-dirs-mounted-as-volumes:
-	@mkdir -p $(CURDIR)/priv/{uploads,db}
+	@mkdir -p $(CURDIR)/priv/{uploads,db,db11}
 
 .PHONY: bootstrap-image
 bootstrap-image: build-bootstrap-image publish-bootstrap-image ## bi  | Build & publish thechangelog/bootstrap Docker image

--- a/baton.cfg
+++ b/baton.cfg
@@ -1,0 +1,5 @@
+GET,http://localhost:4000/,,,
+GET,http://localhost:4000/topics,,,
+GET,http://localhost:4000/posts,,,
+GET,http://localhost:4000/master/feed,,,
+GET,http://localhost:4000/podcast/feed,,,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ version: "3.6"
 
 services:
   db:
-    image: postgres:9.5.4
+    image: postgres:11.1
     # https://docs.docker.com/compose/compose-file/#ports
     expose:
       - "5432"
     # https://docs.docker.com/compose/compose-file/#volumes
     volumes:
-      - ./priv/db:/var/lib/postgresql/data
+      - ./priv/db11:/var/lib/postgresql/data
   app:
     build:
       context: ./

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,12 +1,19 @@
 FROM thechangelog/changelog.com
 
-ENV MIX_ENV prod
+# Modify the latest production image to test changes locally, in the local stack
+# before promoting them into Dockerfile.production
 
-EXPOSE 4000
-HEALTHCHECK --start-period=30s --interval=30s --timeout=30s --retries=3 \
-  CMD curl --output /dev/null --fail --silent http://127.0.0.1:4000 || exit 1
+ENV TERM=xterm
 
-CMD make report-deploy ; mix do ecto.create, ecto.migrate, phx.server
+HEALTHCHECK --start-period=60s --interval=30s --timeout=30s --retries=3 \
+  CMD curl --output /dev/null --fail --silent http://127.0.0.1:4000/ || exit 1
 
-COPY ./config /app/config
+# It's safest to copy files which have dependencies already met in the current production
+# If you find yourself needing to test changes which require a new mix dep, or asset recompilation, consider using `gmake contrib` instead
+# COPY ./config /app/config
+# COPY ./lib/changelog_web/controllers/feed_controller.ex /app/lib/changelog_web/controllers/feed_controller.ex
+COPY ./lib/changelog_web/endpoint.ex /app/lib/changelog_web/endpoint.ex
+COPY ./priv/static/version.txt /app/priv/static/version.txt
 COPY ./Makefile /app/Makefile
+
+CMD make report-deploy ; elixir --sname changelog -S mix do ecto.create, ecto.migrate, phx.server

--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -4,10 +4,12 @@ RUN mkdir /app
 COPY . /app
 WORKDIR /app
 
-ENV MIX_ENV prod
+ENV MIX_ENV=prod
+ENV TERM=xterm
 
 EXPOSE 4000
-HEALTHCHECK --start-period=30s --interval=30s --timeout=30s --retries=3 \
-  CMD curl --output /dev/null --fail --silent http://127.0.0.1:4000 || exit 1
 
-CMD make report-deploy ; mix do ecto.create, ecto.migrate, phx.server
+HEALTHCHECK --start-period=60s --interval=30s --timeout=30s --retries=3 \
+  CMD curl --output /dev/null --fail --silent http://127.0.0.1:4000/ || exit 1
+
+CMD make report-deploy ; elixir --sname changelog -S mix do ecto.create, ecto.migrate, phx.server

--- a/docker/changelog.stack.local.yml
+++ b/docker/changelog.stack.local.yml
@@ -29,6 +29,23 @@ services:
     image: postgres:9.5.4
     volumes:
       - ${PWD}/priv/db:/var/lib/postgresql/data:rw
+  db11:
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+    environment:
+      POSTGRES_USER: &pg_user postgres
+      POSTGRES_DB: &pg_db changelog
+      # https://www.postgresql.org/docs/11/libpq-envars.html
+      PGUSER: *pg_user
+      PGDATABASE: *pg_db
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      start_period: 5s
+    image: postgres:11.1
+    volumes:
+      - ${PWD}/priv/db11:/var/lib/postgresql/data:rw
   app:
     deploy:
       replicas: 1
@@ -41,7 +58,7 @@ services:
         order: start-first
     environment:
       NODE: "${HOSTNAME}"
-      DB_URL: "ecto://postgres@db:5432/changelog"
+      DB_URL: "ecto://postgres@db11:5432/changelog"
       PORT: 4000
       URL_HOST: &host "${USER}.changelog.com"
       URL_PORT: 80
@@ -70,7 +87,7 @@ services:
       - ALGOLIA_API_KEY
       - DB_URL
     depends_on:
-      - db
+      - db11
     image: thechangelog/changelog.com:local
     ports:
       - "4000:4000"

--- a/docker/changelog.stack.local.yml
+++ b/docker/changelog.stack.local.yml
@@ -12,23 +12,6 @@ services:
     image: gliderlabs/logspout:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-  db:
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: any
-    environment:
-      POSTGRES_USER: &pg_user postgres
-      POSTGRES_DB: &pg_db changelog
-      # https://www.postgresql.org/docs/9.5/libpq-envars.html
-      PGUSER: *pg_user
-      PGDATABASE: *pg_db
-    healthcheck:
-      test: ["CMD", "pg_isready"]
-      start_period: 5s
-    image: postgres:9.5.4
-    volumes:
-      - ${PWD}/priv/db:/var/lib/postgresql/data:rw
   db11:
     deploy:
       replicas: 1

--- a/docker/changelog.stack.local.yml
+++ b/docker/changelog.stack.local.yml
@@ -41,7 +41,7 @@ services:
         order: start-first
     environment:
       NODE: "${HOSTNAME}"
-      DB_URL: "ecto://postgres@db11:5432/changelog"
+      DB_URL: "ecto://postgres@db11:5432/changelog" # DB_URL secret has precendence over this!
       PORT: 4000
       URL_HOST: &host "${USER}.changelog.com"
       URL_PORT: 80
@@ -68,7 +68,6 @@ services:
       - COVERALLS_REPO_TOKEN
       - ALGOLIA_APPLICATION_ID
       - ALGOLIA_API_KEY
-      - DB_URL
     depends_on:
       - db11
     image: thechangelog/changelog.com:local
@@ -182,6 +181,4 @@ secrets:
   ALGOLIA_APPLICATION_ID:
     external: true
   ALGOLIA_API_KEY:
-    external: true
-  DB_URL:
     external: true

--- a/docker/changelog.stack.local.yml
+++ b/docker/changelog.stack.local.yml
@@ -1,118 +1,8 @@
 version: "3.7"
 
 services:
-  log:
-    command: syslog+tls://logs7.papertrailapp.com:14349
-    deploy:
-      mode: global
-      restart_policy:
-        condition: any
-    environment:
-      SYSLOG_HOSTNAME: "${USER}"
-    image: gliderlabs/logspout:latest
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-  db11:
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: any
-    environment:
-      POSTGRES_USER: &pg_user postgres
-      POSTGRES_DB: &pg_db changelog
-      # https://www.postgresql.org/docs/11/libpq-envars.html
-      PGUSER: *pg_user
-      PGDATABASE: *pg_db
-    healthcheck:
-      test: ["CMD", "pg_isready"]
-      start_period: 5s
-    image: postgres:11.1
-    volumes:
-      - ${PWD}/priv/db11:/var/lib/postgresql/data:rw
-  app:
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: any
-      # https://docs.docker.com/compose/compose-file/#update_config
-      update_config:
-        failure_action: rollback
-        monitor: 60s
-        order: start-first
-    environment:
-      NODE: "${HOSTNAME}"
-      DB_URL: "ecto://postgres@db11:5432/changelog" # DB_URL secret has precendence over this!
-      PORT: 4000
-      URL_HOST: &host "${USER}.changelog.com"
-      URL_PORT: 80
-      URL_SCHEME: http
-      URL_STATIC_HOST: *host
-      VIRTUAL_HOST: *host
-      ROLLBAR_ENVIRONMENT: local
-    secrets:
-      - CM_API_TOKEN
-      - CM_SMTP_TOKEN
-      - GITHUB_API_TOKEN
-      - GITHUB_CLIENT_ID
-      - GITHUB_CLIENT_SECRET
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - TWITTER_CONSUMER_KEY
-      - TWITTER_CONSUMER_SECRET
-      - SECRET_KEY_BASE
-      - SIGNING_SALT
-      - SLACK_INVITE_API_TOKEN
-      - SLACK_APP_API_TOKEN
-      - ROLLBAR_ACCESS_TOKEN
-      - BUFFER_TOKEN
-      - COVERALLS_REPO_TOKEN
-      - ALGOLIA_APPLICATION_ID
-      - ALGOLIA_API_KEY
-    depends_on:
-      - db11
-    image: thechangelog/changelog.com:local
-    ports:
-      - "4000:4000"
-    volumes:
-      - ${PWD}/priv/uploads:/uploads:rw
-  app_updater:
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: on-failure
-        max_attempts: 3
-      # https://docs.docker.com/compose/compose-file/#update_config
-      update_config:
-        failure_action: rollback
-        monitor: 30s
-        order: stop-first
-    command: update_service_continuously
-    environment:
-      HOSTNAME: "${HOSTNAME}"
-      UPDATE_SERVICE_EVERY_N_SECONDS: 10
-      DOCKER_SERVICE_IMAGE: thechangelog/changelog.com:local
-    image: thechangelog/bootstrap
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - changelog.com:/app:rw
-  proxy:
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: any
-      update_config:
-        failure_action: rollback
-        monitor: 15s
-        order: start-first
-    image: thechangelog/proxy
-    environment:
-      DEFAULT_HOST: *host
-    ports:
-      - "80:80"
-    volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ${PWD}/priv/uploads:/var/www/uploads:ro
   netdata:
+    image: netdata/netdata
     deploy:
       replicas: 1
       restart_policy:
@@ -121,7 +11,10 @@ services:
         failure_action: rollback
         monitor: 30s
         order: start-first
-    image: netdata/netdata
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 1G
     hostname: "${USER}-netdata"
     environment:
       VIRTUAL_HOST: "${USER}-netdata.changelog.com"
@@ -140,6 +33,137 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${PWD}/docker/netdata/postgres.conf:/etc/netdata/python.d/postgres.conf
+      - ${PWD}/docker/netdata/nginx.conf:/etc/netdata/python.d/nginx.conf
+    depends_on:
+      - db11
+      - proxy
+  # log:
+  #   image: gliderlabs/logspout:latest
+  #   command: syslog+tls://logs7.papertrailapp.com:14349
+  #   deploy:
+  #     mode: global
+  #     restart_policy:
+  #       condition: any
+  #     resources:
+  #       limits:
+  #         cpus: "0.5"
+  #         memory: 1G
+  #   environment:
+  #     SYSLOG_HOSTNAME: "${USER}"
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock:ro
+  # app_updater:
+  #   image: thechangelog/bootstrap
+  #   deploy:
+  #     replicas: 1
+  #     restart_policy:
+  #       condition: on-failure
+  #       max_attempts: 3
+  #     # https://docs.docker.com/compose/compose-file/#update_config
+  #     update_config:
+  #       failure_action: rollback
+  #       monitor: 30s
+  #       order: stop-first
+  #   command: update_service_continuously
+  #   environment:
+  #     HOSTNAME: "${HOSTNAME}"
+  #     UPDATE_SERVICE_EVERY_N_SECONDS: 10
+  #     DOCKER_SERVICE_IMAGE: thechangelog/changelog.com:local
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock:ro
+  #     - changelog.com:/app:rw
+  app:
+    image: thechangelog/changelog.com:local
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+      # https://docs.docker.com/compose/compose-file/#update_config
+      update_config:
+        failure_action: rollback
+        monitor: 60s
+        order: start-first
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
+    environment:
+      NODE: "${HOSTNAME}"
+      DB_URL: "ecto://postgres@db11:5432/changelog" # DB_URL secret has precendence over this!
+      PORT: 4000
+      URL_HOST: &host "${USER}.changelog.com"
+      URL_PORT: 80
+      URL_SCHEME: http
+      URL_STATIC_HOST: *host
+      VIRTUAL_HOST: *host
+      ROLLBAR_ENVIRONMENT: local
+      ELIXIR_ERL_OPTIONS: "+S 2:2 +A 128 +K true"
+    secrets:
+      - CM_API_TOKEN
+      - CM_SMTP_TOKEN
+      - GITHUB_API_TOKEN
+      - GITHUB_CLIENT_ID
+      - GITHUB_CLIENT_SECRET
+      - TWITTER_CONSUMER_KEY
+      - TWITTER_CONSUMER_SECRET
+      - SECRET_KEY_BASE
+      - SIGNING_SALT
+      - SLACK_INVITE_API_TOKEN
+      - SLACK_APP_API_TOKEN
+      - ROLLBAR_ACCESS_TOKEN
+      - BUFFER_TOKEN
+      - COVERALLS_REPO_TOKEN
+      - ALGOLIA_APPLICATION_ID
+      - ALGOLIA_API_KEY
+    depends_on:
+      - db11
+    ports:
+      - "4000:4000"
+    volumes:
+      - ${PWD}/priv/uploads:/uploads:rw
+  db11:
+    image: postgres:11.1
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
+    environment:
+      POSTGRES_USER: &pg_user postgres
+      POSTGRES_DB: &pg_db changelog
+      # https://www.postgresql.org/docs/11/libpq-envars.html
+      PGUSER: *pg_user
+      PGDATABASE: *pg_db
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      start_period: 30s
+    volumes:
+      - ${PWD}/priv/db11:/var/lib/postgresql/data:rw
+  proxy:
+    image: thechangelog/proxy:2019-02-07.183116
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+      update_config:
+        failure_action: rollback
+        monitor: 15s
+        order: start-first
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+    environment:
+      DEFAULT_HOST: *host
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ${PWD}/priv/uploads:/var/www/uploads:ro
 
 volumes:
   changelog.com:
@@ -155,10 +179,6 @@ secrets:
   GITHUB_CLIENT_ID:
     external: true
   GITHUB_CLIENT_SECRET:
-    external: true
-  AWS_ACCESS_KEY_ID:
-    external: true
-  AWS_SECRET_ACCESS_KEY:
     external: true
   TWITTER_CONSUMER_KEY:
     external: true

--- a/docker/changelog.stack.yml
+++ b/docker/changelog.stack.yml
@@ -25,7 +25,7 @@ services:
       PGDATABASE: *pg_db
     healthcheck:
       test: ["CMD", "pg_isready"]
-      start_period: 5s
+      start_period: 30s
     image: postgres:9.5.4
     volumes:
       - /db:/var/lib/postgresql/data:rw
@@ -128,7 +128,7 @@ services:
       # We want to see container names in netdata, not container IDs
       # Defining the docker group id makes it possible, as described in https://hub.docker.com/r/netdata/netdata/
       # gmake ssh && grep docker /etc/group | cut -d ':' -f 3
-      PGID: 233
+      PGID: 233 # docker on CoreOS
       # netdata container is too verbose, tell Logspout to not send logs to Papertrail
       # https://github.com/gliderlabs/logspout#ignoring-specific-containers
       LOGSPOUT: ignore

--- a/docker/netdata/nginx.conf
+++ b/docker/netdata/nginx.conf
@@ -1,0 +1,15 @@
+#/* vim: set ft=yaml : */
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+priority: 20000
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+autodetection_retry: 30
+
+localipv4:
+  name: proxy
+  url: 'http://proxy/nginx_status'

--- a/docker/netdata/postgres.conf
+++ b/docker/netdata/postgres.conf
@@ -1,0 +1,23 @@
+#/* vim: set ft=yaml : */
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+priority: 10000
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+autodetection_retry: 30
+
+update_every: 10
+tcp:
+    name: db11
+    database: postgres
+    user: postgres
+    host: db11
+    port: 5432
+    table_stats: true
+    index_stats: true
+    database_poll: changelog
+

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.11",
-    "serial": 67,
+    "serial": 71,
     "lineage": "7d1b7dbf-2d86-ace3-74b2-b78d98c50993",
     "modules": [
         {
@@ -76,6 +76,27 @@
                     },
                     "deposed": [],
                     "provider": "provider.linode"
+                },
+                "data.template_file.db11_mount": {
+                    "type": "template_file",
+                    "depends_on": [
+                        "linode_volume.db11"
+                    ],
+                    "primary": {
+                        "id": "cb29ae24c163fbcac3173a99ebef48fcd45e257035400cd93a7899ec70d8f799",
+                        "attributes": {
+                            "id": "cb29ae24c163fbcac3173a99ebef48fcd45e257035400cd93a7899ec70d8f799",
+                            "rendered": "[Unit]\nDescription=/dev/disk/by-id/scsi-0Linode_Volume_db11 volume to /db11\nBefore=docker.service\n\n[Mount]\nWhat=/dev/disk/by-id/scsi-0Linode_Volume_db11\nWhere=/db11\n\n[Install]\nWantedBy=docker.service\n",
+                            "template": "[Unit]\nDescription=${DISK} volume to ${MOUNT_PATH}\nBefore=docker.service\n\n[Mount]\nWhat=${DISK}\nWhere=${MOUNT_PATH}\n\n[Install]\nWantedBy=docker.service\n",
+                            "vars.%": "2",
+                            "vars.DISK": "/dev/disk/by-id/scsi-0Linode_Volume_db11",
+                            "vars.MOUNT_PATH": "/db11"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.template"
                 },
                 "data.template_file.db_mount": {
                     "type": "template_file",
@@ -522,10 +543,10 @@
                         "id": "12286103",
                         "attributes": {
                             "alerts.#": "1",
-                            "alerts.0.cpu": "90",
+                            "alerts.0.cpu": "300",
                             "alerts.0.io": "10000",
-                            "alerts.0.network_in": "10",
-                            "alerts.0.network_out": "10",
+                            "alerts.0.network_in": "100",
+                            "alerts.0.network_out": "100",
                             "alerts.0.transfer_quota": "80",
                             "authorized_users.#": "3",
                             "authorized_users.0": "gerhard-changelog",
@@ -552,7 +573,10 @@
                             "config.0.devices.0.sdd.0.disk_id": "0",
                             "config.0.devices.0.sdd.0.disk_label": "",
                             "config.0.devices.0.sdd.0.volume_id": "19663",
-                            "config.0.devices.0.sde.#": "0",
+                            "config.0.devices.0.sde.#": "1",
+                            "config.0.devices.0.sde.0.disk_id": "0",
+                            "config.0.devices.0.sde.0.disk_label": "",
+                            "config.0.devices.0.sde.0.volume_id": "25109",
                             "config.0.devices.0.sdf.#": "0",
                             "config.0.devices.0.sdg.#": "0",
                             "config.0.devices.0.sdh.#": "0",
@@ -643,9 +667,9 @@
                             "label": "2019",
                             "region": "us-east",
                             "transfer.%": "3",
-                            "transfer.in": "1077.221508026123",
-                            "transfer.out": "109012.73068714142",
-                            "transfer.total": "110089.95219516754",
+                            "transfer.in": "19118.36992263794",
+                            "transfer.out": "2.059717053683281e+06",
+                            "transfer.total": "2.078835423605919e+06",
                             "updated": "2019-01-03T00:34:16Z"
                         },
                         "meta": {},
@@ -804,6 +828,35 @@
                     "deposed": [],
                     "provider": "provider.linode"
                 },
+                "linode_volume.db11": {
+                    "type": "linode_volume",
+                    "depends_on": [
+                        "data.linode_region.changelog",
+                        "linode_instance.2019"
+                    ],
+                    "primary": {
+                        "id": "25109",
+                        "attributes": {
+                            "filesystem_path": "/dev/disk/by-id/scsi-0Linode_Volume_db11",
+                            "id": "25109",
+                            "label": "db11",
+                            "linode_id": "12286103",
+                            "region": "us-east",
+                            "size": "10",
+                            "status": "active"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 600000000000,
+                                "delete": 600000000000,
+                                "update": 1200000000000
+                            }
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.linode"
+                },
                 "linode_volume.uploads": {
                     "type": "linode_volume",
                     "depends_on": [
@@ -858,11 +911,11 @@
                         "linode_instance.2019"
                     ],
                     "primary": {
-                        "id": "7204536463740006438",
+                        "id": "7937189103477204661",
                         "attributes": {
-                            "id": "7204536463740006438",
+                            "id": "7937189103477204661",
                             "triggers.%": "1",
-                            "triggers.always": "2019-02-01T15:02:08Z"
+                            "triggers.always": "2019-02-08T09:25:45Z"
                         },
                         "meta": {},
                         "tainted": false
@@ -892,19 +945,21 @@
                 "null_resource.mount_volumes": {
                     "type": "null_resource",
                     "depends_on": [
+                        "data.template_file.db11_mount",
                         "data.template_file.db_mount",
                         "data.template_file.uploads_mount",
                         "linode_instance.2019",
                         "linode_volume.db",
+                        "linode_volume.db11",
                         "linode_volume.uploads"
                     ],
                     "primary": {
-                        "id": "5215558085931610462",
+                        "id": "8845918393862129920",
                         "attributes": {
-                            "id": "5215558085931610462",
+                            "id": "8845918393862129920",
                             "triggers.%": "2",
                             "triggers.instance_id": "12286103",
-                            "triggers.manually": "2018.12.28-16:05"
+                            "triggers.manually": "2019.02.08-09:17"
                         },
                         "meta": {},
                         "tainted": false

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.11",
-    "serial": 67,
+    "serial": 71,
     "lineage": "7d1b7dbf-2d86-ace3-74b2-b78d98c50993",
     "modules": [
         {
@@ -76,6 +76,27 @@
                     },
                     "deposed": [],
                     "provider": "provider.linode"
+                },
+                "data.template_file.db11_mount": {
+                    "type": "template_file",
+                    "depends_on": [
+                        "linode_volume.db11"
+                    ],
+                    "primary": {
+                        "id": "cb29ae24c163fbcac3173a99ebef48fcd45e257035400cd93a7899ec70d8f799",
+                        "attributes": {
+                            "id": "cb29ae24c163fbcac3173a99ebef48fcd45e257035400cd93a7899ec70d8f799",
+                            "rendered": "[Unit]\nDescription=/dev/disk/by-id/scsi-0Linode_Volume_db11 volume to /db11\nBefore=docker.service\n\n[Mount]\nWhat=/dev/disk/by-id/scsi-0Linode_Volume_db11\nWhere=/db11\n\n[Install]\nWantedBy=docker.service\n",
+                            "template": "[Unit]\nDescription=${DISK} volume to ${MOUNT_PATH}\nBefore=docker.service\n\n[Mount]\nWhat=${DISK}\nWhere=${MOUNT_PATH}\n\n[Install]\nWantedBy=docker.service\n",
+                            "vars.%": "2",
+                            "vars.DISK": "/dev/disk/by-id/scsi-0Linode_Volume_db11",
+                            "vars.MOUNT_PATH": "/db11"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.template"
                 },
                 "data.template_file.db_mount": {
                     "type": "template_file",
@@ -287,6 +308,28 @@
                     "deposed": [],
                     "provider": "provider.dnsimple"
                 },
+                "dnsimple_record.ci_changelog_com": {
+                    "type": "dnsimple_record",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "15206888",
+                        "attributes": {
+                            "domain": "changelog.com",
+                            "domain_id": "changelog.com",
+                            "hostname": "ci.changelog.com",
+                            "id": "15206888",
+                            "name": "ci",
+                            "priority": "0",
+                            "ttl": "60",
+                            "type": "URL",
+                            "value": "https://circleci.com/gh/thechangelog/changelog.com"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.dnsimple"
+                },
                 "dnsimple_record.code_changelog_com": {
                     "type": "dnsimple_record",
                     "depends_on": [],
@@ -302,6 +345,116 @@
                             "ttl": "60",
                             "type": "URL",
                             "value": "https://github.com/thechangelog/changelog.com"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.dnsimple"
+                },
+                "dnsimple_record.dns_changelog_com": {
+                    "type": "dnsimple_record",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "15206884",
+                        "attributes": {
+                            "domain": "changelog.com",
+                            "domain_id": "changelog.com",
+                            "hostname": "dns.changelog.com",
+                            "id": "15206884",
+                            "name": "dns",
+                            "priority": "0",
+                            "ttl": "60",
+                            "type": "URL",
+                            "value": "https://dnsimple.com/a/10898/domains/changelog.com/dns"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.dnsimple"
+                },
+                "dnsimple_record.docker_changelog_com": {
+                    "type": "dnsimple_record",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "15206890",
+                        "attributes": {
+                            "domain": "changelog.com",
+                            "domain_id": "changelog.com",
+                            "hostname": "docker.changelog.com",
+                            "id": "15206890",
+                            "name": "docker",
+                            "priority": "0",
+                            "ttl": "60",
+                            "type": "URL",
+                            "value": "https://hub.docker.com/u/thechangelog"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.dnsimple"
+                },
+                "dnsimple_record.errors_changelog_com": {
+                    "type": "dnsimple_record",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "15206889",
+                        "attributes": {
+                            "domain": "changelog.com",
+                            "domain_id": "changelog.com",
+                            "hostname": "errors.changelog.com",
+                            "id": "15206889",
+                            "name": "errors",
+                            "priority": "0",
+                            "ttl": "60",
+                            "type": "URL",
+                            "value": "https://rollbar.com/changelogmedia/changelog.com/"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.dnsimple"
+                },
+                "dnsimple_record.logs_changelog_com": {
+                    "type": "dnsimple_record",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "15206887",
+                        "attributes": {
+                            "domain": "changelog.com",
+                            "domain_id": "changelog.com",
+                            "hostname": "logs.changelog.com",
+                            "id": "15206887",
+                            "name": "logs",
+                            "priority": "0",
+                            "ttl": "60",
+                            "type": "URL",
+                            "value": "https://papertrailapp.com/systems/2019/"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.dnsimple"
+                },
+                "dnsimple_record.monitoring_changelog_com": {
+                    "type": "dnsimple_record",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "15206885",
+                        "attributes": {
+                            "domain": "changelog.com",
+                            "domain_id": "changelog.com",
+                            "hostname": "monitoring.changelog.com",
+                            "id": "15206885",
+                            "name": "monitoring",
+                            "priority": "0",
+                            "ttl": "60",
+                            "type": "URL",
+                            "value": "https://my.pingdom.com/reports/uptime#daterange=7days\u0026tab=uptime_tab\u0026check=2310619"
                         },
                         "meta": {},
                         "tainted": false
@@ -326,6 +479,28 @@
                             "ttl": "60",
                             "type": "A",
                             "value": "69.164.223.133"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.dnsimple"
+                },
+                "dnsimple_record.secrets_changelog_com": {
+                    "type": "dnsimple_record",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "15206886",
+                        "attributes": {
+                            "domain": "changelog.com",
+                            "domain_id": "changelog.com",
+                            "hostname": "secrets.changelog.com",
+                            "id": "15206886",
+                            "name": "secrets",
+                            "priority": "0",
+                            "ttl": "60",
+                            "type": "URL",
+                            "value": "https://lastpass.com/?\u0026ac=1"
                         },
                         "meta": {},
                         "tainted": false
@@ -368,10 +543,10 @@
                         "id": "12286103",
                         "attributes": {
                             "alerts.#": "1",
-                            "alerts.0.cpu": "90",
+                            "alerts.0.cpu": "300",
                             "alerts.0.io": "10000",
-                            "alerts.0.network_in": "10",
-                            "alerts.0.network_out": "10",
+                            "alerts.0.network_in": "100",
+                            "alerts.0.network_out": "100",
                             "alerts.0.transfer_quota": "80",
                             "authorized_users.#": "3",
                             "authorized_users.0": "gerhard-changelog",
@@ -398,7 +573,10 @@
                             "config.0.devices.0.sdd.0.disk_id": "0",
                             "config.0.devices.0.sdd.0.disk_label": "",
                             "config.0.devices.0.sdd.0.volume_id": "19663",
-                            "config.0.devices.0.sde.#": "0",
+                            "config.0.devices.0.sde.#": "1",
+                            "config.0.devices.0.sde.0.disk_id": "0",
+                            "config.0.devices.0.sde.0.disk_label": "",
+                            "config.0.devices.0.sde.0.volume_id": "25109",
                             "config.0.devices.0.sdf.#": "0",
                             "config.0.devices.0.sdg.#": "0",
                             "config.0.devices.0.sdh.#": "0",
@@ -489,9 +667,9 @@
                             "label": "2019",
                             "region": "us-east",
                             "transfer.%": "3",
-                            "transfer.in": "1046.7773084640503",
-                            "transfer.out": "106603.6462802887",
-                            "transfer.total": "107650.42358875275",
+                            "transfer.in": "19110.938532829285",
+                            "transfer.out": "2.059145033173561e+06",
+                            "transfer.total": "2.0782559717063904e+06",
                             "updated": "2019-01-03T00:34:16Z"
                         },
                         "meta": {},
@@ -650,6 +828,35 @@
                     "deposed": [],
                     "provider": "provider.linode"
                 },
+                "linode_volume.db11": {
+                    "type": "linode_volume",
+                    "depends_on": [
+                        "data.linode_region.changelog",
+                        "linode_instance.2019"
+                    ],
+                    "primary": {
+                        "id": "25109",
+                        "attributes": {
+                            "filesystem_path": "/dev/disk/by-id/scsi-0Linode_Volume_db11",
+                            "id": "25109",
+                            "label": "db11",
+                            "linode_id": "12286103",
+                            "region": "us-east",
+                            "size": "10",
+                            "status": "active"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 600000000000,
+                                "delete": 600000000000,
+                                "update": 1200000000000
+                            }
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.linode"
+                },
                 "linode_volume.uploads": {
                     "type": "linode_volume",
                     "depends_on": [
@@ -704,11 +911,11 @@
                         "linode_instance.2019"
                     ],
                     "primary": {
-                        "id": "3366983111519152637",
+                        "id": "6911648927398594671",
                         "attributes": {
-                            "id": "3366983111519152637",
+                            "id": "6911648927398594671",
                             "triggers.%": "1",
-                            "triggers.always": "2019-02-01T14:51:49Z"
+                            "triggers.always": "2019-02-08T09:18:01Z"
                         },
                         "meta": {},
                         "tainted": false
@@ -738,22 +945,24 @@
                 "null_resource.mount_volumes": {
                     "type": "null_resource",
                     "depends_on": [
+                        "data.template_file.db11_mount",
                         "data.template_file.db_mount",
                         "data.template_file.uploads_mount",
                         "linode_instance.2019",
                         "linode_volume.db",
+                        "linode_volume.db11",
                         "linode_volume.uploads"
                     ],
                     "primary": {
-                        "id": "5215558085931610462",
+                        "id": "4197968791611702995",
                         "attributes": {
-                            "id": "5215558085931610462",
+                            "id": "4197968791611702995",
                             "triggers.%": "2",
                             "triggers.instance_id": "12286103",
-                            "triggers.manually": "2018.12.28-16:05"
+                            "triggers.manually": "2019.02.08-09:17"
                         },
                         "meta": {},
-                        "tainted": false
+                        "tainted": true
                     },
                     "deposed": [],
                     "provider": "provider.null"


### PR DESCRIPTION
We are currently using PostgreSQL v9.5.4 and need to upgrade - the container image is 2 years old.

Since an in-place upgrade from v9.5.4 to v9.5.15 is not supported, we might as well use the db dump & import to go to latest stable, v11.1

## Development

- [x] Measure `GET /master/feed` - uncached `~736ms` - cached - `~150µs`
- [x] Upgrade PostgreSQL to v11.1
- [x] Dump & import production db
- [x] Measure `GET /master/feed` - uncached `~645ms` - cached - `~150µs`

## Local Docker Stack

- [x] Measure `GET /master/feed` - uncached `~800ms` - cached - `~80µs`
- [x] Deploy PostgreSQL v11.1 alongside v9.5.4
- [x] Dump & import production db into v11.1
- [x] Deploy new app version to use PostgreSQL v11.1
- [x] Confirm that there is no downtime during app update
- [x] Measure `GET /master/feed` - uncached `~800ms` - cached - `~80µs`
- [x] Remove PostgreSQL v9.5.4

### PostgreSQL v9.5.4, no feed caching

```
time parallel hey -c 1 -n 100 -- http://gerhard.changelog.com/{podcast,gotime,jsparty,practicalai,spotlight,master}/feed
1m27.051s
```

![screenshot 2019-02-06 at 22 19 22](https://user-images.githubusercontent.com/3342/52378082-a977bd80-2a5e-11e9-8ba9-27bdceb0a30f.png)

### PostgreSQL v11.1, no feed caching

```
time parallel hey -c 1 -n 100 -- http://gerhard.changelog.com/{podcast,gotime,jsparty,practicalai,spotlight,master}/feed
1m28.409s
```

![screenshot 2019-02-06 at 22 25 36](https://user-images.githubusercontent.com/3342/52378156-d9bf5c00-2a5e-11e9-8f24-4894b5701926.png)

## Production Docker Stack

- [ ] Deploy PostgreSQL v11.1 alongside v9.5.4
- [ ] Dump & import production db into v11.1
- [ ] Deploy new app version which uses PostgreSQL v11.1 - `DB_URL` secret
- [ ] Remove PostgreSQL v9.5.4