### PR TITLE
Default to using Jason instead of Poison

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,8 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :phoenix, :json_library, Jason
+
 config :phoenix, :generators,
   migration: true,
   binary_id: false

--- a/lib/changelog_web/endpoint.ex
+++ b/lib/changelog_web/endpoint.ex
@@ -33,7 +33,7 @@ defmodule ChangelogWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Poison,
+    json_decoder: Phoenix.json_library(),
     length: 200_000_000
 
   plug Plug.MethodOverride


### PR DESCRIPTION
Phoenix 1.4+ recommends using Jason instead of Poison and in Phoenix 2.0 the new default will be Jason.