### PR TITLE
[admin] Add foreign key constraints to post form

### DIFF
--- a/lib/changelog/schema/post/post_topic.ex
+++ b/lib/changelog/schema/post/post_topic.ex
@@ -17,6 +17,8 @@ defmodule Changelog.PostTopic do
     struct
     |> cast(params, ~w(position post_id topic_id delete)a)
     |> validate_required([:position])
+    |> foreign_key_constraint(:post_id)
+    |> foreign_key_constraint(:topic_id)
     |> mark_for_deletion()
   end
 end

--- a/lib/changelog_web/templates/admin/post/_form.html.eex
+++ b/lib/changelog_web/templates/admin/post/_form.html.eex
@@ -48,6 +48,8 @@
               <%= hidden_input i, :delete %>
             </a>
           </div>
+
+          <%= error_message(i, :topic_id) %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Without this in place, if you manually fiddled around with the HTML
source of the input fields, you could input an invalid topic_id which
causes Ecto to throw an exception since it violates the constraint at
the database level.

This patch adds the validation at the changeset level so we can display
a friendly error if the FK ids aren't available.