### PR TITLE
Add /health route for doing health checks

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -5,8 +5,12 @@ FROM thechangelog/changelog.com
 
 # It's safest to copy files which have dependencies already met in the current production
 # If you find yourself needing to test changes which require a new mix dep, or asset recompilation, consider using `gmake contrib` instead
+COPY ./lib/changelog_web/endpoint.ex /app/lib/changelog_web/endpoint.ex
+COPY ./lib/changelog_web/plugs/health_check.ex /app/lib/changelog_web/plugs/health_check.ex
 COPY ./config /app/config
+
 RUN date -u +'%Y-%m-%dT%H:%M:%SZ' > /app/priv/static/version.txt
+
 COPY ./Makefile /app/Makefile
 
 CMD elixir --sname changelog -S mix do ecto.create, ecto.migrate, phx.server

--- a/docker/changelog.stack.local.yml
+++ b/docker/changelog.stack.local.yml
@@ -77,7 +77,7 @@ services:
         monitor: 115s
         order: start-first
     healthcheck:
-      test: ["CMD", "curl", "--output", "/dev/null", "--fail", "--fail-early",  "--silent",  "http://127.0.0.1:4000/"]
+      test: ["CMD", "curl", "--output", "/dev/null", "--fail", "--fail-early",  "--silent",  "http://127.0.0.1:4000/health"]
       interval: 15s
       timeout: 15s
       retries: 3

--- a/docker/changelog.stack.yml
+++ b/docker/changelog.stack.yml
@@ -79,7 +79,7 @@ services:
         monitor: 115s
         order: start-first
     healthcheck:
-      test: ["CMD", "curl", "--output", "/dev/null", "--fail", "--fail-early",  "--silent",  "http://127.0.0.1:4000/"]
+      test: ["CMD", "curl", "--output", "/dev/null", "--fail", "--fail-early",  "--silent",  "http://127.0.0.1:4000/health"]
       interval: 15s
       timeout: 15s
       retries: 3

--- a/lib/changelog_web/endpoint.ex
+++ b/lib/changelog_web/endpoint.ex
@@ -4,6 +4,8 @@ defmodule ChangelogWeb.Endpoint do
   socket "/socket", ChangelogWeb.UserSocket,
     websocket: true # or list of options
 
+  plug(ChangelogWeb.Plug.HealthCheck)
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phoenix.digest

--- a/lib/changelog_web/plugs/health_check.ex
+++ b/lib/changelog_web/plugs/health_check.ex
@@ -1,0 +1,13 @@
+defmodule ChangelogWeb.Plug.HealthCheck do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{request_path: "/health"} = conn, _opts) do
+    conn
+    |> send_resp(200, "")
+    |> halt()
+  end
+
+  def call(conn, _opts), do: conn
+end


### PR DESCRIPTION
Previously the health check was hitting the home page which rendered a
full response back of the home page and wrote a log entry for that
request.

With this new set up, an empty 200 gets returned and since it's loaded
at the beginning of the Endpoint, it bypasses the logger and other
plugs which helps eliminate log spam and serve the health check more
efficiently.