### PR TITLE
WIP: Use Elixir Releases

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,7 @@
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
 use Mix.Config
-Code.load_file("config/docker_secret.exs")
+Code.require_file("docker_secret.exs", "config")
 
 config :changelog, ChangelogWeb.Endpoint,
   url: [host: "localhost"],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,6 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
 config :changelog, ChangelogWeb.Endpoint,
+  env: :dev,
   http: [port: 4000],
   static_url: [host: (System.get_env("HOST") || "localhost"), port: 4000],
   debug_errors: true,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,10 +1,20 @@
-use Mix.Config
+import Config
+# TODO: consider converting to Config.Provider:
+# https://hexdocs.pm/elixir/Config.Provider.html
+Code.require_file("docker_secret.exs", "config")
 
 config :changelog,
-  env: :prod
+  env: :prod,
+  ecto_repos: [Changelog.Repo],
+  buffer_token: DockerSecret.get("BUFFER_TOKEN_2"),
+  github_api_token: DockerSecret.get("GITHUB_API_TOKEN2"),
+  cm_api_token: Base.encode64("#{DockerSecret.get("CM_API_TOKEN")}:x"),
+  slack_invite_api_token: DockerSecret.get("SLACK_INVITE_API_TOKEN"),
+  slack_app_api_token: DockerSecret.get("SLACK_APP_API_TOKEN")
 
 config :changelog, ChangelogWeb.Endpoint,
-  http: [port: System.get_env("PORT")],
+  http: [port: String.to_integer(System.fetch_env!("PORT"))],
+  server: true,
   url: [scheme: (System.get_env("URL_SCHEME") || "https"), host: (System.get_env("URL_HOST") || "changelog.com"), port: (System.get_env("URL_PORT") || 443)],
   force_ssl: [
     rewrite_on: [:x_forwarded_proto],
@@ -14,7 +24,8 @@ config :changelog, ChangelogWeb.Endpoint,
   static_url: [scheme: (System.get_env("URL_SCHEME") || "https"), host: (System.get_env("URL_STATIC_HOST") || "cdn.changelog.com"), port: (System.get_env("URL_PORT") || 443)],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
-config :logger, level: :info
+config :logger,
+  level: :info
 # config :logger, :console, level: :debug, format: "[$level] $message\n"
 
 config :arc,
@@ -45,3 +56,19 @@ config :changelog, Changelog.Scheduler,
 config :rollbax,
   access_token: DockerSecret.get("ROLLBAR_ACCESS_TOKEN"),
   environment: "production"
+
+config :ex_aws,
+  access_key_id: DockerSecret.get("AWS_ACCESS_KEY_ID"),
+  secret_access_key: DockerSecret.get("AWS_SECRET_ACCESS_KEY")
+
+config :ueberauth, Ueberauth.Strategy.Github.OAuth,
+  client_id: DockerSecret.get("GITHUB_CLIENT_ID"),
+  client_secret: DockerSecret.get("GITHUB_CLIENT_SECRET")
+
+config :ueberauth, Ueberauth.Strategy.Twitter.OAuth,
+  consumer_key: DockerSecret.get("TWITTER_CONSUMER_KEY"),
+  consumer_secret: DockerSecret.get("TWITTER_CONSUMER_SECRET")
+
+config :algolia,
+  application_id: DockerSecret.get("ALGOLIA_APPLICATION_ID"),
+  api_key: DockerSecret.get("ALGOLIA_API_KEY")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,10 @@
 use Mix.Config
 
+config :changelog,
+  env: :test
+
 # We don't run a server during test. If one is required,
-# you can enable the server option below.
+# you can set the server option below to true.
 config :changelog, ChangelogWeb.Endpoint,
   http: [port: 4001],
   server: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - deps:/app/deps
       - ./lib:/app/lib
       - ./priv:/app/priv
+      - ./rel:/app/rel
       - ./script:/app/script
       - ./test:/app/test
       - ./.all-contributorsrc:/app/.all-contributorsrc

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -1,4 +1,4 @@
-FROM circleci/elixir:1.8-node
+FROM circleci/elixir:1.9-node
 
 USER root
 

--- a/lib/changelog/search.ex
+++ b/lib/changelog/search.ex
@@ -48,7 +48,7 @@ defmodule Changelog.Search do
     }
   end
 
-  defp namespace, do: "#{Mix.env}_news_items"
+  defp namespace, do: "#{Application.get_env(:changelog, :env)}_news_items"
 
   defp indexed_attributes(item) do
     %{

--- a/lib/changelog_web/endpoint.ex
+++ b/lib/changelog_web/endpoint.ex
@@ -18,7 +18,7 @@ defmodule ChangelogWeb.Endpoint do
   # In dev environment, serve uploaded files from "priv/uploads".
   #
   # Nginx will serve these in production.
-  if Mix.env == :dev do
+  if Application.get_env(:changelog, :env) == :dev do
     plug Plug.Static,
       at: "/uploads", from: {:changelog, "priv/uploads"}, gzip: false, headers: %{"Accept-Ranges" => "bytes"}
   end

--- a/lib/changelog_web/helpers/shared_helpers.ex
+++ b/lib/changelog_web/helpers/shared_helpers.ex
@@ -50,7 +50,7 @@ defmodule ChangelogWeb.Helpers.SharedHelpers do
   def current_path(conn, params), do: Controller.current_path(conn, params)
 
   def dev_relative(url) do
-    if Mix.env == :dev do
+    if Application.get_env(:changelog, :env) == :dev do
       parsed = URI.parse(url)
       [parsed.path, parsed.fragment] |> ListKit.compact_join("#")
     else

--- a/lib/changelog_web/router.ex
+++ b/lib/changelog_web/router.ex
@@ -4,7 +4,7 @@ defmodule ChangelogWeb.Router do
 
   alias ChangelogWeb.Plug
 
-  if Mix.env == :dev do
+  if Application.get_env(:changelog, :env) == :dev do
     forward "/sent_emails", Bamboo.SentEmailViewerPlug
   end
 

--- a/lib/changelog_web/templates/auth/new.html.eex
+++ b/lib/changelog_web/templates/auth/new.html.eex
@@ -3,7 +3,7 @@
 
   <%= if @person do %>
     <div class="form_submit_response form_submit_response--success"><p>Check your email! We sent you a single-use sign in link. It will expire in <%= auth_link_expires_in(@person) %>.</p></div>
-    <%= if Mix.env == :dev do %>
+    <%= if Application.get_env(:changelog, :env) == :dev do %>
       <p>Psst! Since you're hacking we'll just skip the email process. <%= link "click here", to: auth_path(@conn, @person), data: [turbolinks: false] %> instead!</p>
     <% end %>
   <% else %>

--- a/lib/changelog_web/templates/layout/_head_scripts.html.eex
+++ b/lib/changelog_web/templates/layout/_head_scripts.html.eex
@@ -1,4 +1,4 @@
-<%= if Mix.env == :prod do %>
+<%= if Application.get_env(:changelog, :env) == :prod do %>
 <script>
   (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/lib/changelog_web/templates/shared/_drift_js.html.eex
+++ b/lib/changelog_web/templates/shared/_drift_js.html.eex
@@ -1,4 +1,4 @@
-<%= if Mix.env == :prod do %>
+<%= if Application.get_env(:changelog, :env) == :prod do %>
 <script>
 !function() {
  var t;

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Sets and enables heart (recommended only in daemon mode)
+# case $RELEASE_COMMAND in
+#   daemon*)
+#     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
+#     export HEART_COMMAND
+#     export ELIXIR_ERL_OPTIONS="-heart"
+#     ;;
+#   *)
+#     ;;
+# esac
+
+# Set the release to work across nodes. If using the long name format like
+# the one below (my_app@127.0.0.1), you need to also uncomment the
+# RELEASE_DISTRIBUTION variable below.
+# export RELEASE_DISTRIBUTION=name
+# export RELEASE_NODE=<%= @release.name %>@127.0.0.1

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, etc)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10


### PR DESCRIPTION
This is a second attempt to upgrade Elixir. We've hit the slow boot time issue with the 1.8 upgrade and were forced to revert: https://github.com/thechangelog/changelog.com/commit/7d32773dc7859e086eaebcf899cb628d22d78ea0

This is a great moment to roll out releases, [a new Elixir 1.9 feature](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/), and start addressing the fat image, slow boot times & unnecessary compilation. It's one of the improvements that we had in sight [since we announced the new setup for 2019](https://changelog.com/posts/the-new-changelog-setup-for-2019).

This is currently WIP, sharing early.