### PR TITLE
Expand news items by default in list views

### DIFF
--- a/lib/changelog_web/templates/news_item/_summary.html.eex
+++ b/lib/changelog_web/templates/news_item/_summary.html.eex
@@ -1,10 +1,9 @@
 <article class="news_item js-track-news" data-news-type="news" data-news-id="<%= hashid(@item) %>">
   <%= render("_header.html", assigns) %>
-<%= if @item.story do %>
-  <%= link to: permalink_path(@conn, @item), class: "news_item-description", data: permalink_data(@item) do %>
-    <p><%= @item.story |> md_to_text %></p>
-    <p class="news_item-description-continue"><span>read more</span></p>
-  <% end %>
-<% end %>
-  <%= render("_toolbar.html", assigns) %>
+  <%= render("_toolbar.html", Map.put(assigns, :style, "date")) %>
+  <div class="news_item-content richtext">
+    <%= @item.story |> md_to_html() |> raw() %>
+    <%= video_embed(@item) %>
+  </div>
+  <%= image_link(@item) %>
 </article>

--- a/lib/changelog_web/templates/news_item/show.html.eex
+++ b/lib/changelog_web/templates/news_item/show.html.eex
@@ -1,13 +1,5 @@
 <div class="page_news_item">
-  <article class="news_item js-track-news" data-news-type="news" data-news-id="<%= hashid(@item) %>">
-    <%= render("_header.html", assigns) %>
-    <%= render("_toolbar.html", Map.put(assigns, :style, "date")) %>
-    <div class="news_item-content richtext">
-      <%= @item.story |> md_to_html() |> raw() %>
-      <%= video_embed(@item) %>
-    </div>
-    <%= image_link(@item) %>
-  </article>
+  <%= render("_summary.html", assigns) %>
 
   <%= render(SharedView, "_signup_banner.html", assigns) %>
   <%= render("_comments.html", assigns) %>

--- a/lib/changelog_web/views/news_item_view.ex
+++ b/lib/changelog_web/views/news_item_view.ex
@@ -155,9 +155,6 @@ defmodule ChangelogWeb.NewsItemView do
       render("toolbar/_button_video.html", conn: conn, item: item, id: id)
     end
   end
-  def render_toolbar_button(conn, item = %{image: image}) when not is_nil(image) do
-    render("toolbar/_button_image.html", conn: conn, item: item)
-  end
   def render_toolbar_button(_conn, _item), do: nil
 
   def render_youtube_embed(nil), do: nil


### PR DESCRIPTION
I want to try expanding news items by default as I think it may result in a better user experience. News items are often short anyway, truncating them sometimes does not make much sense. There are some long ones, but usually due to images, which are engaging and perhaps shouldn't always be hidden behind a click.