### PR TITLE
Fix art issue for Safari on "minimal" show headers

### DIFF
--- a/assets/app/layout/show.scss
+++ b/assets/app/layout/show.scss
@@ -76,6 +76,7 @@
         .show-header--minimal & {
           display: flex;
           justify-content: center;
+          align-items: center;
         }
 
         img {


### PR DESCRIPTION
@jerodsanto This should fix the bug with the stretched image in Safari that presented itself on the minimal version of show headers (like paginated page views).