### PR TITLE
Reduce compilation dependencies of the router

### DIFF
--- a/lib/changelog_web/plugs/admin_layout_plug.ex
+++ b/lib/changelog_web/plugs/admin_layout_plug.ex
@@ -1,0 +1,7 @@
+defmodule ChangelogWeb.Plug.AdminLayoutPlug do
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    Phoenix.Controller.put_layout(conn, {ChangelogWeb.LayoutView, :admin})
+  end
+end

--- a/lib/changelog_web/router.ex
+++ b/lib/changelog_web/router.ex
@@ -31,7 +31,7 @@ defmodule ChangelogWeb.Router do
   end
 
   pipeline :admin do
-    plug :put_layout, {ChangelogWeb.LayoutView, :admin}
+    plug Plug.AdminLayoutPlug
   end
 
   pipeline :public do


### PR DESCRIPTION
By moving the `put_layout` call to a plug, the Router no longer needs to refer to the LayoutView at compile time. This results in the router only being recompiled if 2 files change instead of 100+

This is especially helpful since according to `mix compile --profile=time` the router takes about 5 seconds to compile (on my machine)

Note: this analysis applies to Elixir 1.11 and may be different on earlier versions of elixir.