### PR TITLE
Fixing Episode tracker N+1 query

### DIFF
--- a/lib/changelog/prom_ex.ex
+++ b/lib/changelog/prom_ex.ex
@@ -16,6 +16,13 @@ defmodule Changelog.PromEx do
   end
 
   @impl true
+  def dashboard_assigns do
+    [
+      datasource_id: "prometheus"
+    ]
+  end
+
+  @impl true
   def dashboards do
     [
       # PromEx built in dashboard definitions. Remove dashboards that you do not need

--- a/test/changelog/episode_tracker_test.exs
+++ b/test/changelog/episode_tracker_test.exs
@@ -58,7 +58,30 @@ defmodule Changelog.MetacastsTest do
         podcast: changelog
       )
 
-    assert {:ok, [%{slug: "rails-episode"}]} = EpisodeTracker.filter("only podcast: podcast")
+    assert {:ok,
+            [
+              %{
+                slug: "rails-episode",
+                guest: [],
+                host: [],
+                id: 2,
+                podcast: "podcast",
+                title: "Rails",
+                topic: [],
+                type: :full
+              },
+              %{
+                guest: [],
+                host: [],
+                id: 3,
+                podcast: "podcast",
+                slug: "django-episode",
+                title: "Django",
+                topic: [],
+                type: :full
+              }
+            ]} = EpisodeTracker.filter("only podcast: podcast")
+
     EpisodeTracker.track(episode)
 
     assert {:ok, [%{slug: "django-episode"}, %{slug: "rails-episode"}]} =

--- a/test/changelog/episode_tracker_test.exs
+++ b/test/changelog/episode_tracker_test.exs
@@ -46,7 +46,10 @@ defmodule Changelog.MetacastsTest do
   end
 
   test "track new episode then untrack", %{podcasts: [_, changelog, _]} do
+    # Calling :sys.get_state in order to ensure that the handle_cast occurs before the
+    # DB insert in order to make the test deterministic
     EpisodeTracker.refresh()
+    _ = :sys.get_state(EpisodeTracker)
 
     episode =
       insert(:published_episode,
@@ -58,29 +61,7 @@ defmodule Changelog.MetacastsTest do
         podcast: changelog
       )
 
-    assert {:ok,
-            [
-              %{
-                slug: "rails-episode",
-                guest: [],
-                host: [],
-                id: 2,
-                podcast: "podcast",
-                title: "Rails",
-                topic: [],
-                type: :full
-              },
-              %{
-                guest: [],
-                host: [],
-                id: 3,
-                podcast: "podcast",
-                slug: "django-episode",
-                title: "Django",
-                topic: [],
-                type: :full
-              }
-            ]} = EpisodeTracker.filter("only podcast: podcast")
+    assert {:ok, [%{slug: "rails-episode"}]} = EpisodeTracker.filter("only podcast: podcast")
 
     EpisodeTracker.track(episode)
 


### PR DESCRIPTION
This PR fixes an N+1 query that is caused by the episode tracker. Running the new implementation against the old implementation, I saw via the PromEx metrics that only a single Postgres query was made as opposed to 6,782 queries that were being made prior:
```
OLD -> # changelog_prom_ex_ecto_repo_query_decode_time_milliseconds_count{repo="Changelog.Repo"} 6782

NEW -> # changelog_prom_ex_ecto_repo_query_decode_time_milliseconds_count{repo="Changelog.Repo"} 1
```

In doing this, I think I also discovered a bug in the episode tracker filter and fixed that with the single query and updated the tests to reflect the real results from the filter.