### PR TITLE
Fixing Prom datasource ID

### DIFF
--- a/lib/changelog/prom_ex.ex
+++ b/lib/changelog/prom_ex.ex
@@ -18,7 +18,7 @@ defmodule Changelog.PromEx do
   @impl true
   def dashboard_assigns do
     [
-      datasource_id: "prometheus"
+      datasource_id: "Prometheus"
     ]
   end
 


### PR DESCRIPTION
Forgot that the Prometheus datasource ID is capital `P`...fixing that so the dashboards work again.