### PR TITLE
removed "assign" from sign_in_and_redirect/3

### DIFF
--- a/lib/changelog_web/controllers/auth_controller.ex
+++ b/lib/changelog_web/controllers/auth_controller.ex
@@ -69,7 +69,6 @@ defmodule ChangelogWeb.AuthController do
     person |> Person.sign_in_changes() |> Repo.update()
 
     conn
-    |> assign(:current_user, person)
     |> put_flash(:success, "Welcome to Changelog!")
     |> put_session("id", person.id)
     |> configure_session(renew: true)


### PR DESCRIPTION
`assign` stores value in current request's connection struct and since we are using `|> redirect(to: route)`, it will never make it there