### PR TITLE
🎁 Auto-restoring K8s clusters

### DIFF
--- a/2021/Makefile
+++ b/2021/Makefile
@@ -38,9 +38,9 @@ endef
 
 include $(CURDIR)/deps.mk
 include $(CURDIR)/dagger.mk
-include $(CURDIR)/crossplane.mk
 include $(CURDIR)/linode.mk
 include $(CURDIR)/secrets.mk
+include $(CURDIR)/crossplane.mk
 include $(CURDIR)/grafana-agent.mk
 include $(CURDIR)/honeycomb-agent.mk
 include $(CURDIR)/metrics-server.mk

--- a/2021/Makefile
+++ b/2021/Makefile
@@ -38,6 +38,7 @@ endef
 
 include $(CURDIR)/deps.mk
 include $(CURDIR)/dagger.mk
+include $(CURDIR)/crossplane.mk
 include $(CURDIR)/linode.mk
 include $(CURDIR)/secrets.mk
 include $(CURDIR)/grafana-agent.mk

--- a/2021/crossplane.mk
+++ b/2021/crossplane.mk
@@ -16,10 +16,10 @@ up: $(UP)
 releases-up:
 	$(OPEN) $(UP_RELEASES)
 
-# christmas-2021-gift:
-# https://cloud.upbound.io/changelogmedia/controlPlanes/bd465974-fb45-47a4-b9a5-001db23c89c8
+# christmas-2021-gift: https://cloud.upbound.io/changelogmedia/controlPlanes/bd465974-fb45-47a4-b9a5-001db23c89c8
 UPBOUND_CONTROLPLANE_ID := bd465974-fb45-47a4-b9a5-001db23c89c8
 UPBOUND_KUBECONFIG := $(XDG_CONFIG_HOME)/upbound.$(UPBOUND_CONTROLPLANE_ID).yml
+UPBOUND_CONTROLPLANE_NAMESPACE := upbound-system
 $(UPBOUND_KUBECONFIG):
 	touch $(UPBOUND_KUBECONFIG)
 
@@ -33,7 +33,8 @@ env:: | $(LPASS)
 $(HOME)/.up/config.json: | $(UP)
 	$(UP) login
 
-up_connect: $(HOME)/.up/config.json $(UPBOUND_KUBECONFIG)
+.PHONY: up-connect
+up-connect: $(HOME)/.up/config.json $(UPBOUND_KUBECONFIG)
 ifndef UP_TOKEN
 	$(call env_not_set,UP_TOKEN)
 endif
@@ -42,3 +43,132 @@ endif
 		   --token=$(UP_TOKEN) $(UPBOUND_CONTROLPLANE_ID)
 	@printf "$(BOLD)$(GREEN)OK!$(NORMAL)\n"
 	@printf "To use this control plane, run: $(BOLD)export KUBECONFIG=$(UPBOUND_KUBECONFIG)$(NORMAL)\n"
+
+# STORY ########################################################################
+#
+# 1. Why did we do this?
+# - We wanted our Kubernetes clusters to not be provisioned via UI or CLI.
+# - We wanted to apply a config and have the cluster be continuously reconciled
+# - If one of us accidentally deletes it, the cluster should be automatically re-created and everything restored
+#
+# 2. How did we do this?
+# - We mentioned in episode 15 about wanting to make Crossplane part of the Changelog 2022 setup
+# - We are running our Kubernetes clusters of Linode, and there is no Crossplane provider for Linode that works + Marques
+# - We have heard of this new and easy ways of generating new Crossplane providers: Terrajet
+# - Muvaffak Onus is here today to tells us about it!
+#   - Why did you create Terrajet?
+#   - How many providers have been generated with Terrajet?
+#   - What is coming next for Terrajet?
+# - We generated a new Linode Provider using Terrajet which is now in crossplane-contrib
+# - Anyone can use this provider to have Crossplane manage K8s clusters on Linode (a.k.a. LKE)
+#
+# 3. This is how we are doing it
+# - Install Crossplane
+# - Install Provider
+# - Provision LKE cluster with Provider
+# - Target LKE cluster
+# - What happens if someone "accidentally" deletes a cluster? 😎
+#
+# 4. What happens next?
+# - Install everything that is needed on the LKE cluster using a Composition
+#   - base composition:
+#     - grafana-agent (sed + envsubst + kubectl)
+#     - honeycomb-agent (helm)
+#     - metrics-server (curl + gsed + kubectl)
+#     - external-dns (envsubst + kubectl)
+#     - cert-manager (helm)
+#     - ingress-nginx (helm)
+#     - local-path-provisioner (helm)
+#     - keel (helm)
+#   - changelog composition (envsubst + kubectl)
+# - Move Crossplane to Upbound Cloud
+#   - developer consoles
+#   - UI
+#   - team permissions
+#   - compositions
+CROSSPLANE_VERSION := 1.5.1
+CROSSPLANE_NAMESPACE := crossplane-system
+CROSSPLANE_RELEASES := https://charts.crossplane.io/stable
+.PHONY: lke-crossplane
+lke-crossplane: | lke-ctx $(HELM)
+	@printf "\n$(MAGENTA)Installing Crossplane v$(CROSSPLANE_VERSION)...$(NORMAL)\n"
+	$(HELM) repo add crossplane-stable $(CROSSPLANE_RELEASES)
+	$(HELM) repo update
+	$(HELM) upgrade crossplane crossplane-stable/crossplane \
+		--install \
+		--namespace $(CROSSPLANE_NAMESPACE) --create-namespace \
+		--version $(CROSSPLANE_VERSION) \
+		--wait
+
+lke-bootstrap:: | lke-crossplane
+
+.PHONY: releases-crossplane
+releases-crossplane:
+	$(OPEN) $(CROSSPLANE_RELEASES)
+
+# Given:
+# - a host with Docker installed:
+# - a clone of https://github.com/crossplane-contrib/provider-jet-linode
+#
+# Run the following commands:
+# make generate
+# make build PLATFORMS=linux_amd64 DOCKER_REGISTRY=thechangelog
+# make publish PLATFORMS=linux_amd64 DOCKER_REGISTRY=thechangelog
+#
+# And now re-tag both images without -amd64, e.g.
+# docker tag build-d25cec7d/provider-jet-linode-controller-amd64 thechangelog/provider-jet-linode-controller:v0.0.0-8.g79d76b3
+# docker push thechangelog/provider-jet-linode-controller:v0.0.0-8.g79d76b3
+# docker tag build-d25cec7d/provider-jet-linode-amd64 thechangelog/provider-jet-linode:v0.0.0-8.g79d76b3
+# docker push thechangelog/provider-jet-linode:v0.0.0-8.g79d76b3
+#
+# Update the provider version below:
+CROSSPLANE_PROVIDER_LINODE_VERSION := v0.0.0-12.ge4dcf7e
+.PHONY: crossplane-linode-provider
+crossplane-linode-provider: | lke-ctx
+	@printf "\n$(MAGENTA)Adding Linode Token...$(NORMAL)\n"
+	$(KUBECTL) create secret generic linode \
+	  --from-literal=token="$$($(LPASS) show --notes Shared-changelog/secrets/LINODE_CLI_TOKEN)" --dry-run=client --output json \
+	| $(KUBECTL) $(K_CMD) --namespace $(CROSSPLANE_NAMESPACE) --filename -
+	@printf "\n$(MAGENTA)Installing Crossplane Provider Linode v$(CROSSPLANE_PROVIDER_LINODE_VERSION)...$(NORMAL)\n"
+	export NAMESPACE=$(CROSSPLANE_NAMESPACE) \
+	; export PROVIDER_LINODE_VERSION=$(CROSSPLANE_PROVIDER_LINODE_VERSION) \
+	; cat $(CURDIR)/manifests/crossplane/provider-jet-linode/{controller-config,provider}.yml \
+	| $(ENVSUBST_SAFE) \
+	| $(KUBECTL) $(K_CMD) --filename -
+	$(KUBECTL) wait --for=condition=healthy provider/jet-linode --timeout=60s --namespace $(CROSSPLANE_NAMESPACE)
+	@printf "\n$(MAGENTA)Configuring Crossplane Provider Linode...$(NORMAL)\n"
+	export NAMESPACE=$(CROSSPLANE_NAMESPACE) \
+	; cat $(CURDIR)/manifests/crossplane/provider-jet-linode/provider-config.yml \
+	| $(ENVSUBST_SAFE) \
+	| $(KUBECTL) $(K_CMD) --filename -
+
+CROSSPLANE_LKE_NAME ?= lke-$(shell date -u +'%Y-%m-%d')
+CROSSPLANE_LKE_K8S_VERSION ?= 1.22
+CROSSPLANE_LKE_REGION ?= us-east
+CROSSPLANE_LKE_WORKER_NODES_TYPE ?= g6-dedicated-4
+CROSSPLANE_LKE_WORKER_NODES_COUNT ?= 1
+CROSSPLANE_RUNNING_IN ?= $(LKE_LABEL)
+.PHONY: crossplane-lke
+crossplane-lke: | $(KUBECTL)
+	@printf "\n$(MAGENTA)Creating $(BOLD)$(CROSSPLANE_LKE_NAME)$(NORMAL)$(MAGENTA) running K8s $(BOLD)v$(CROSSPLANE_LKE_K8S_VERSION)$(NORMAL)$(MAGENTA) in $(BOLD)$(CROSSPLANE_LKE_REGION)$(NORMAL) ...$(NORMAL)\n"
+	export NAME=$(CROSSPLANE_LKE_NAME) \
+	; export NAMESPACE=$(CROSSPLANE_NAMESPACE) \
+	; export K8S_VERSION=$(CROSSPLANE_LKE_K8S_VERSION) \
+	; export REGION=$(CROSSPLANE_LKE_REGION) \
+	; export WORKER_NODES_COUNT=$(CROSSPLANE_LKE_WORKER_NODES_COUNT) \
+	; export WORKER_NODES_TYPE=$(CROSSPLANE_LKE_WORKER_NODES_TYPE) \
+	; export CROSSPLANE_RUNNING_IN=$(CROSSPLANE_RUNNING_IN) \
+	; export CROSSPLANE_VERSION=$(CROSSPLANE_VERSION) \
+	; export PROVIDER_LINODE_VERSION=$(CROSSPLANE_PROVIDER_LINODE_VERSION) \
+	; cat $(CURDIR)/manifests/crossplane/lke.yml \
+	| $(ENVSUBST_SAFE) \
+	| $(KUBECTL) $(K_CMD) --filename -
+
+.PHONY: crossplane-lke-kubeconfig
+crossplane-lke-kubeconfig: | $(KUBECTL)
+	@printf "\n$(MAGENTA)Saving $(BOLD)$(CROSSPLANE_LKE_NAME)$(NORMAL)$(MAGENTA) LKE cluster config to $(BOLD)$(LKE_CONFIGS)/$(CROSSPLANE_LKE_NAME).yml$(NORMAL)$(MAGENTA)...$(NORMAL)\n"
+	$(KUBECTL) get secret/$(CROSSPLANE_LKE_NAME) \
+		--namespace $(CROSSPLANE_NAMESPACE) \
+		--template={{.data.kubeconfig}} \
+	| base64 --decode > $(LKE_CONFIGS)/$(CROSSPLANE_LKE_NAME).yml
+	@printf "\nTo use this config, run $(BOLD)export KUBECONFIG=$(LKE_CONFIGS)/$(CROSSPLANE_LKE_NAME).yml$(NORMAL)\n"

--- a/2021/crossplane.mk
+++ b/2021/crossplane.mk
@@ -44,48 +44,6 @@ endif
 	@printf "$(BOLD)$(GREEN)OK!$(NORMAL)\n"
 	@printf "To use this control plane, run: $(BOLD)export KUBECONFIG=$(UPBOUND_KUBECONFIG)$(NORMAL)\n"
 
-# STORY ########################################################################
-#
-# 1. Why did we do this?
-# - We wanted our Kubernetes clusters to not be provisioned via UI or CLI.
-# - We wanted to apply a config and have the cluster be continuously reconciled
-# - If one of us accidentally deletes it, the cluster should be automatically re-created and everything restored
-#
-# 2. How did we do this?
-# - We mentioned in episode 15 about wanting to make Crossplane part of the Changelog 2022 setup
-# - We are running our Kubernetes clusters of Linode, and there is no Crossplane provider for Linode that works + Marques
-# - We have heard of this new and easy ways of generating new Crossplane providers: Terrajet
-# - Muvaffak Onus is here today to tells us about it!
-#   - Why did you create Terrajet?
-#   - How many providers have been generated with Terrajet?
-#   - What is coming next for Terrajet?
-# - We generated a new Linode Provider using Terrajet which is now in crossplane-contrib
-# - Anyone can use this provider to have Crossplane manage K8s clusters on Linode (a.k.a. LKE)
-#
-# 3. This is how we are doing it
-# - Install Crossplane
-# - Install Provider
-# - Provision LKE cluster with Provider
-# - Target LKE cluster
-# - What happens if someone "accidentally" deletes a cluster? 😎
-#
-# 4. What happens next?
-# - Install everything that is needed on the LKE cluster using a Composition
-#   - base composition:
-#     - grafana-agent (sed + envsubst + kubectl)
-#     - honeycomb-agent (helm)
-#     - metrics-server (curl + gsed + kubectl)
-#     - external-dns (envsubst + kubectl)
-#     - cert-manager (helm)
-#     - ingress-nginx (helm)
-#     - local-path-provisioner (helm)
-#     - keel (helm)
-#   - changelog composition (envsubst + kubectl)
-# - Move Crossplane to Upbound Cloud
-#   - developer consoles
-#   - UI
-#   - team permissions
-#   - compositions
 CROSSPLANE_VERSION := 1.5.1
 CROSSPLANE_NAMESPACE := crossplane-system
 CROSSPLANE_RELEASES := https://charts.crossplane.io/stable

--- a/2021/crossplane.mk
+++ b/2021/crossplane.mk
@@ -1,0 +1,10 @@
+# - [ ] Delete providers from https://cloud.upbound.io/changelogmedia/controlPlanes/16e3a96e-6505-4ad8-af96-098d5ba1eba4/settings
+# - [ ] Delete control plane
+# - [ ] Create new control plane - ensure it gets provisioned as v1.4.x-up
+# - [ ] Use provider-tf-template to generate a Linode Crossplane provider from Terraform
+# 	- https://github.com/crossplane-contrib/provider-tf-template
+# 	- https://github.com/linode/terraform-provider-linode + https://registry.terraform.io/providers/linode/linode/latest/docs
+# 	- https://github.com/crossplane-contrib/terrajet (the tool behind it)
+# - [ ] Use a composite resource to provision the cluster + node pools, don't provision them separately
+# 	- https://github.com/upbound/platform-ref-multi-k8s
+# - [ ] Provision baseline K8s components via the composite resource, e.g. external-dns, traefik, etc.

--- a/2021/crossplane.mk
+++ b/2021/crossplane.mk
@@ -1,10 +1,44 @@
-# - [ ] Delete providers from https://cloud.upbound.io/changelogmedia/controlPlanes/16e3a96e-6505-4ad8-af96-098d5ba1eba4/settings
-# - [ ] Delete control plane
-# - [ ] Create new control plane - ensure it gets provisioned as v1.4.x-up
-# - [ ] Use provider-tf-template to generate a Linode Crossplane provider from Terraform
-# 	- https://github.com/crossplane-contrib/provider-tf-template
-# 	- https://github.com/linode/terraform-provider-linode + https://registry.terraform.io/providers/linode/linode/latest/docs
-# 	- https://github.com/crossplane-contrib/terrajet (the tool behind it)
-# - [ ] Use a composite resource to provision the cluster + node pools, don't provision them separately
-# 	- https://github.com/upbound/platform-ref-multi-k8s
-# - [ ] Provision baseline K8s components via the composite resource, e.g. external-dns, traefik, etc.
+UP_RELEASES := https://cli.upbound.io/stable
+UP_VERSION := 0.5.0
+UP_BIN := up-$(UP_VERSION)-$(platform)-amd64
+https://cli.upbound.io/stable/v0.5.0/bin/darwin_amd64/up
+UP_URL := $(UP_RELEASES)/v$(UP_VERSION)/bin/$(platform)_amd64/up
+UP := $(LOCAL_BIN)/$(UP_BIN)
+$(UP): | $(CURL) $(LOCAL_BIN)
+	$(CURL) --progress-bar --fail --location --output $(UP) "$(UP_URL)"
+	touch $(UP)
+	chmod +x $(UP)
+	$(UP) --version | grep $(UP_VERSION)
+	ln -sf $(UP) $(LOCAL_BIN)/up
+.PHONY: up
+up: $(UP)
+.PHONY: releases-up
+releases-up:
+	$(OPEN) $(UP_RELEASES)
+
+# christmas-2021-gift:
+# https://cloud.upbound.io/changelogmedia/controlPlanes/bd465974-fb45-47a4-b9a5-001db23c89c8
+UPBOUND_CONTROLPLANE_ID := bd465974-fb45-47a4-b9a5-001db23c89c8
+UPBOUND_KUBECONFIG := $(XDG_CONFIG_HOME)/upbound.$(UPBOUND_CONTROLPLANE_ID).yml
+$(UPBOUND_KUBECONFIG):
+	touch $(UPBOUND_KUBECONFIG)
+
+env:: | $(LPASS)
+	@$(LPASS) status --quiet \
+	|| ( printf "$(RED)LastPass session expired, run $(BOLD)lpass login <YOUR_EMAIL_ADDRESS>$(NORMAL)\n" ; exit 1 )
+	@echo 'export UP_TOKEN="$(shell $(LPASS) show --notes Shared-changelog/secrets/UPBOUND_CLOUD_USER_TOKEN)"'
+	@echo 'export UP_ACCOUNT="changelogmedia"'
+	@echo 'export UP_PROFILE="default"'
+
+$(HOME)/.up/config.json: | $(UP)
+	$(UP) login
+
+up_connect: $(HOME)/.up/config.json $(UPBOUND_KUBECONFIG)
+ifndef UP_TOKEN
+	$(call env_not_set,UP_TOKEN)
+endif
+	@printf "Connecting to Upbound Cloud Control Plane $(BOLD)$(UPBOUND_CONTROLPLANE_ID)$(NORMAL) ... "
+	@KUBECONFIG=$(UPBOUND_KUBECONFIG) $(UP) controlplane kubeconfig get \
+		   --token=$(UP_TOKEN) $(UPBOUND_CONTROLPLANE_ID)
+	@printf "$(BOLD)$(GREEN)OK!$(NORMAL)\n"
+	@printf "To use this control plane, run: $(BOLD)export KUBECONFIG=$(UPBOUND_KUBECONFIG)$(NORMAL)\n"

--- a/2021/crossplane.mk
+++ b/2021/crossplane.mk
@@ -15,8 +15,8 @@ up: $(UP)
 releases-up:
 	$(OPEN) $(UP_RELEASES)
 
-# christmas-2021-gift: https://cloud.upbound.io/changelogmedia/controlPlanes/bd465974-fb45-47a4-b9a5-001db23c89c8
-UPBOUND_CONTROLPLANE_ID := bd465974-fb45-47a4-b9a5-001db23c89c8
+# 2022: https://cloud.upbound.io/changelogmedia/controlPlanes/d9a7a122-fafe-4c06-a170-d0ad543f371c
+UPBOUND_CONTROLPLANE_ID := d9a7a122-fafe-4c06-a170-d0ad543f371c
 UPBOUND_KUBECONFIG := $(XDG_CONFIG_HOME)/upbound.$(UPBOUND_CONTROLPLANE_ID).yml
 UPBOUND_CONTROLPLANE_NAMESPACE := upbound-system
 $(UPBOUND_KUBECONFIG):
@@ -43,8 +43,8 @@ endif
 	@printf "$(BOLD)$(GREEN)OK!$(NORMAL)\n"
 	@printf "To use this control plane, run: $(BOLD)export KUBECONFIG=$(UPBOUND_KUBECONFIG)$(NORMAL)\n"
 
-CROSSPLANE_VERSION := 1.6.1
-CROSSPLANE_NAMESPACE := crossplane-system
+CROSSPLANE_VERSION ?= 1.5.1
+CROSSPLANE_NAMESPACE ?= crossplane-system
 CROSSPLANE_RELEASES := https://charts.crossplane.io/stable
 .PHONY: lke-crossplane
 lke-crossplane: | lke-ctx $(HELM)
@@ -90,7 +90,7 @@ crossplane-linode-provider: | lke-ctx
 	@printf "\n$(MAGENTA)Installing Crossplane Provider Linode v$(CROSSPLANE_PROVIDER_LINODE_VERSION)...$(NORMAL)\n"
 	export NAMESPACE=$(CROSSPLANE_NAMESPACE) \
 	; export PROVIDER_LINODE_VERSION=$(CROSSPLANE_PROVIDER_LINODE_VERSION) \
-	; cat $(CURDIR)/manifests/crossplane/provider-jet-linode/{controller-config,provider}.yml \
+	; cat $(CURDIR)/manifests/crossplane/provider-jet-linode/provider.yml \
 	| $(ENVSUBST_SAFE) \
 	| $(KUBECTL) $(K_CMD) --filename -
 	$(KUBECTL) wait --for=condition=healthy provider/jet-linode --timeout=60s --namespace $(CROSSPLANE_NAMESPACE)
@@ -99,7 +99,7 @@ crossplane-linode-provider: | lke-ctx
 	; cat $(CURDIR)/manifests/crossplane/provider-jet-linode/provider-config.yml \
 	| $(ENVSUBST_SAFE) \
 	| $(KUBECTL) $(K_CMD) --filename -
-	@printf "\n$(BOLD)✅ Crossplane Provider Linode v$(CROSSPLANE_PROVIDER_LINODE_VERSION) installed!$(NORMAL)\n\n"
+	@printf "\n$(BOLD)✅ Crossplane Provider Linode $(CROSSPLANE_PROVIDER_LINODE_VERSION) installed!$(NORMAL)\n\n"
 
 CROSSPLANE_LKE_NAME ?= lke-$(shell date -u +'%Y-%m-%d')
 CROSSPLANE_LKE_K8S_VERSION ?= 1.22

--- a/2021/deps.mk
+++ b/2021/deps.mk
@@ -29,7 +29,7 @@ $(CURL):
 endif
 
 K9S_RELEASES := https://github.com/derailed/k9s/releases
-K9S_VERSION := 0.25.6
+K9S_VERSION := 0.25.14
 K9S_BIN_DIR := $(LOCAL_BIN)/k9s-$(K9S_VERSION)-$(platform)-x86_64
 K9S_URL := $(K9S_RELEASES)/download/v$(K9S_VERSION)/k9s_$(platform)_x86_64.tar.gz
 K9S := $(K9S_BIN_DIR)/k9s
@@ -46,7 +46,7 @@ releases-k9s:
 	$(OPEN) $(K9S_RELEASES)
 
 YTT_RELEASES := https://github.com/vmware-tanzu/carvel-ytt/releases
-YTT_VERSION := 0.31.0
+YTT_VERSION := 0.38.0
 YTT_BIN := ytt-$(YTT_VERSION)-$(platform)-amd64
 YTT_URL := $(YTT_RELEASES)/download/v$(YTT_VERSION)/ytt-$(platform)-amd64
 YTT := $(LOCAL_BIN)/$(YTT_BIN)
@@ -98,7 +98,7 @@ env::
 	@mkdir -p $(XDG_CONFIG_HOME)/lpass
 
 HELM_RELEASES := https://github.com/helm/helm/releases
-HELM_VERSION := 3.6.3
+HELM_VERSION := 3.7.2
 HELM_BIN_DIR := helm-v$(HELM_VERSION)-$(platform)-amd64
 HELM_URL := https://get.helm.sh/$(HELM_BIN_DIR).tar.gz
 HELM := $(LOCAL_BIN)/$(HELM_BIN_DIR)/$(platform)-amd64/helm

--- a/2021/deps.mk
+++ b/2021/deps.mk
@@ -29,7 +29,7 @@ $(CURL):
 endif
 
 K9S_RELEASES := https://github.com/derailed/k9s/releases
-K9S_VERSION := 0.25.14
+K9S_VERSION := 0.25.18
 K9S_BIN_DIR := $(LOCAL_BIN)/k9s-$(K9S_VERSION)-$(platform)-x86_64
 K9S_URL := $(K9S_RELEASES)/download/v$(K9S_VERSION)/k9s_$(platform)_x86_64.tar.gz
 K9S := $(K9S_BIN_DIR)/k9s

--- a/2021/keel.mk
+++ b/2021/keel.mk
@@ -8,6 +8,7 @@ $(KEEL_DIR):
 	  https://github.com/keel-hq/keel.git $(KEEL_DIR)
 tmp/keel: $(KEEL_DIR)
 
+.PHONY: lke-keel
 lke-keel: | $(KEEL_DIR) lke-ctx $(HELM)
 	$(HELM) upgrade keel $(KEEL_DIR)/chart/keel \
 	  --install \

--- a/2021/manifests/crossplane/lke.yml
+++ b/2021/manifests/crossplane/lke.yml
@@ -1,0 +1,21 @@
+apiVersion: linode.jet.crossplane.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ${NAME}
+  namespace: ${NAMESPACE}
+spec:
+  forProvider:
+    label: ${NAME}
+    k8sVersion: "${K8S_VERSION}"
+    region: ${REGION}
+    pool:
+      - count: ${WORKER_NODES_COUNT}
+        type: ${WORKER_NODES_TYPE}
+    tags:
+      - managed-by-crossplane
+      - created-by-${CROSSPLANE_RUNNING_IN}
+      - created-by-crossplane-${CROSSPLANE_VERSION}
+      - created-by-${PROVIDER_LINODE_VERSION}
+  writeConnectionSecretToRef:
+    name: ${NAME}
+    namespace: ${NAMESPACE}

--- a/2021/manifests/crossplane/provider-jet-linode/controller-config.yml
+++ b/2021/manifests/crossplane/provider-jet-linode/controller-config.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: jet-linode-config
+  namespace: ${NAMESPACE}
+spec:
+  args:
+    - --debug

--- a/2021/manifests/crossplane/provider-jet-linode/controller-config.yml
+++ b/2021/manifests/crossplane/provider-jet-linode/controller-config.yml
@@ -1,9 +1,0 @@
----
-apiVersion: pkg.crossplane.io/v1alpha1
-kind: ControllerConfig
-metadata:
-  name: jet-linode-config
-  namespace: ${NAMESPACE}
-spec:
-  args:
-    - --debug

--- a/2021/manifests/crossplane/provider-jet-linode/provider-config.yml
+++ b/2021/manifests/crossplane/provider-jet-linode/provider-config.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: linode.jet.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  # TODO: how can I change this to jet-linode?
+  name: default
+  namespace: ${NAMESPACE}
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      name: linode
+      namespace: ${NAMESPACE}
+      key: token

--- a/2021/manifests/crossplane/provider-jet-linode/provider.yml
+++ b/2021/manifests/crossplane/provider-jet-linode/provider.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: jet-linode
+  namespace: ${NAMESPACE}
+spec:
+  package: thechangelog/provider-jet-linode:${PROVIDER_LINODE_VERSION}
+  controllerConfigRef:
+    name: jet-linode-config

--- a/2021/manifests/crossplane/provider-jet-linode/provider.yml
+++ b/2021/manifests/crossplane/provider-jet-linode/provider.yml
@@ -6,5 +6,3 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   package: thechangelog/provider-jet-linode:${PROVIDER_LINODE_VERSION}
-  controllerConfigRef:
-    name: jet-linode-config


### PR DESCRIPTION
## Why did we do this?
- No ClickOps - 🙌🏻  &nbsp;@hasheddan - or TerminalOps for our K8s clusters
- We want to tell what we want via a K8s API, and have "the system" figure out how to talk to the IaaS
- If one of us accidentally deletes it, the cluster should be automatically re-created (the intent is in the title)

> 💡 This idea actually started in [Ship It #15 - Assemble all your infrastructure](https://changelog.com/shipit/15), where I was mentioning that we want to make Crossplane part of the Changelog 2022 setup.      
                                                                              
## How did we do this?

We created a new Crossplane provider for Linode using [Terrajet](https://github.com/crossplane/terrajet), a framework for generating Crossplane providers from Terraform providers. This is the end-result: [crossplane-contrib/provider-jet-linode](https://github.com/crossplane-contrib/provider-jet-linode)

These are all the steps, from start to finish:

### 1/5. Install Crossplane
```console
make lke-crossplane
Installing Crossplane v1.6.1...
helm upgrade crossplane crossplane-stable/crossplane \
	--install \
	--namespace crossplane-system --create-namespace \
	--version 1.6.1 \
	--wait
✅ Crossplane v1.6.1 installed!
```

### 2/5. Install  Linode Crossplane Provider
```console
make crossplane-linode-provider
Adding Linode Token...
Installing Crossplane Provider Linode vv0.0.0-12.ge4dcf7e...
Configuring Crossplane Provider Linode...
✅ Crossplane Provider Linode vv0.0.0-12.ge4dcf7e installed!
```

### 3/5. Provision LKE cluster with Provider
```console
export CROSSPLANE_LKE_NAME=lke-2021-12-24
make crossplane-lke
Creating lke-2021-12-24 running K8s v1.22 in us-east ...
✅ lke-2021-12-24 running K8s v1.22 in us-east with 1 worker node(s) of type g6-dedicated-8 created!
```

### 4/5. Target LKE cluster
```console
make crossplane-lke-kubeconfig
Saving lke-2021-12-24 LKE cluster config to /Users/gerhard/github.com/thechangelog/changelog.com/2021/.config/kube/configs/lke-2021-12-24.yml...

✅ To use this config, run export KUBECONFIG=/Users/gerhard/github.com/thechangelog/changelog.com/2021/.config/kube/configs/lke-2021-12-24.yml

export KUBECONFIG=/Users/gerhard/github.com/thechangelog/changelog.com/2021/.config/kube/configs/lke-2021-12-24.yml
make k9s
```

> 💡 The worker node can take up to 5 minutes to get ready after the cluster becomes ready.

![image](https://user-images.githubusercontent.com/3342/149632113-d45ab10f-dbba-4a24-8f22-766f15a13167.png)

### 5/5. What happens if someone "accidentally" deletes a cluster? 😎
![image](https://user-images.githubusercontent.com/3342/149631543-63b0c7c6-db8e-44b2-b8e5-faddd87e7813.png)

Within 1 minute, Crossplane Linode Provider notices that the cluster is missing. 1 minute later, the cluster gets re-created. After another 2 minutes, the worker node appears as not ready. After 1 more minute, the worker node becomes ready. All put together, the cluster will be re-created within 5 minutes of it getting "accidentally" deleted. 🙌🏻                                                                                                                 
                                                                                                                     
## What happens next?
- [x] Run Crossplane & Linode Provider to Upbound Cloud
  - [x] Delete existing LKE cluster if using the same name, otherwise it will fail to create https://github.com/crossplane-contrib/provider-jet-linode/issues/6
  - [x] `make up-connect`
  - [x] `export KUBECONFIG=/Users/gerhard/github.com/thechangelog/changelog.com/2021/.config/upbound.d9a7a122-fafe-4c06-a170-d0ad543f371c.yml` 
  - [x] `export CROSSPLANE_NAMESPACE=upbound-system`
  - [x] `export CROSSPLANE_LKE_NAME=lke-2021-12-24`
  - [x] `export CROSSPLANE_RUNNING_IN=upbound-2022`
  - [x] `export CROSSPLANE_VERSION=1.5.1-up.1`
  - [x] `make crossplane-lke`
- [ ] Tag [crossplane-contrib/provider-jet-linode](https://github.com/crossplane-contrib/provider-jet-linode)
- [ ] Check that https://doc.crds.dev/X gets populated after tagging

## And after that?

- Install everything that is needed on the LKE cluster using a Composition
  - base composition:
    - grafana-agent (sed + envsubst + kubectl)
    - honeycomb-agent (helm)
    - metrics-server (curl + gsed + kubectl)
    - external-dns (envsubst + kubectl)
    - cert-manager (helm)
    - ingress-nginx (helm)
    - local-path-provisioner (helm)
    - keel (helm)
  - changelog composition (envsubst + kubectl)
---

cc @muvaf @hasheddan @jbw976