### PR TITLE
Deploy & use Docker Engine running on Fly.io

### DIFF
--- a/.github/workflows/prod_image.yml
+++ b/.github/workflows/prod_image.yml
@@ -53,6 +53,7 @@ jobs:
   # Requires build_test_ship to commit a fly.toml update, and this workflow triggering on fly.toml updates.
   # 🔥 This is fine for now 🔥
   fly:
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: build_test_ship
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prod_image.yml
+++ b/.github/workflows/prod_image.yml
@@ -20,15 +20,23 @@ jobs:
           age-key: ${{ secrets.DAGGER_AGE_KEY }}
           args: version
 
-      - name: Configure Tailscale tunnel for remote Docker Engine...
-        uses: tailscale/github-action@v1
-        with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+      # ⚠️  FLY_WIREGUARD is configured via `fly wireguard create ...` - see 2022.fly/docker/README.md
+      - name: Set up WireGuard for Fly.io Docker Engine...
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends wireguard-tools openresolv
+          printf "${{ secrets.FLY_WIREGUARD }}" | sudo tee /etc/wireguard/fly.conf
+          sudo wg-quick up fly
 
+      # ⚠️  IPv6 is configured via `fly ips private` - see 2022.fly/docker/README.md
+      - name: Check Fly.io Docker Engine
+        run: |
+          ping6 -c 5 fdaa:0:4556:a7b:21e0:1:1f9d:2
+          nc -vz6 fdaa:0:4556:a7b:21e0:1:1f9d:2 2375
+
+      # ⚠️  IPv6 is configured via `fly ips private` - see 2022.fly/docker/README.md
       - name: Run prod_image Dagger plan on remote Docker Engine...
         env:
-          DOCKER_HOST: "tcp://100.81.87.121:2375"
-          OTEL_EXPORTER_JAEGER_ENDPOINT: "http://100.81.87.121:14268/api/traces"
+          DOCKER_HOST: "tcp://[fdaa:0:4556:a7b:21e0:1:1f9d:2]:2375"
         run: |
           /opt/hostedtoolcache/dagger/*/x64/dagger input text prod_dockerfile --file docker/Dockerfile.production --environment prod_image
           /opt/hostedtoolcache/dagger/*/x64/dagger input text git_branch "$GITHUB_REF_NAME" --environment prod_image

--- a/2022.fly/Makefile
+++ b/2022.fly/Makefile
@@ -68,11 +68,14 @@ $(DAGGER): | $(CURL) $(LOCAL_BIN)
 dagger: | $(DAGGER) .envrc
 	@printf "\nRun $(BOLD)dagger do$(NORMAL) to discover what actions are available\n\n"
 
-FLY_VERSION := 0.0.311
-FLY ?= $(LOCAL_BIN)/fly
+FLY_VERSION := 0.0.333
+FLY_DIR ?= $(LOCAL_BIN)/fly-$(FLY_VERSION)
+FLY ?= $(FLY_DIR)/bin/fly
 $(FLY): | $(CURL) $(LOCAL_BIN)
-	$(CURL) --fail --location https://fly.io/install.sh | FLYCTL_INSTALL=$(CURDIR) sh -ex
+	mkdir -p $(FLY_DIR)
+	$(CURL) --fail --location https://fly.io/install.sh | FLYCTL_INSTALL=$(FLY_DIR) sh -ex
 	$(FLY) version | grep $(FLY_VERSION)
+	ln -sf $(FLY) $(LOCAL_BIN)/fly
 .PHONY: fly
 fly: | $(FLY) .envrc
 

--- a/2022.fly/docker/Dockerfile
+++ b/2022.fly/docker/Dockerfile
@@ -1,0 +1,15 @@
+# https://hub.docker.com/_/docker
+FROM docker:20.10.17
+
+RUN apk add bash ip6tables pigz sysstat procps lsof
+
+COPY etc/docker/daemon.json /etc/docker/daemon.json
+
+COPY ./entrypoint ./entrypoint
+COPY ./docker-entrypoint.d/* ./docker-entrypoint.d/
+
+ENV DOCKER_TMPDIR=/data/docker/tmp
+
+ENTRYPOINT ["./entrypoint"]
+
+CMD ["dockerd", "-p", "/var/run/docker.pid", "--tls=false"]

--- a/2022.fly/docker/README.md
+++ b/2022.fly/docker/README.md
@@ -1,25 +1,59 @@
-# Fly Docker Daemon
+# Docker Engine on Fly.io
 
-This is a Docker Daemon that runs on Fly.io and is used for https://github.com/thechangelog/changelog.com builds primarily.
+This is a Docker Engine that runs on Fly.io.
+It is **only** used for [thechangelog/changelog.com](https://github.com/thechangelog/changelog.com) builds.
+It provides built-in caching & better performance than the free GitHub Actions Runners (4 CPUs vs 2 CPUs).
 
-## Install
 
-1. Create a volume in a region of your choice: `fly volumes create data --size 20 --region iad`
-1. Create a new app: `fly apps create docker-2022-06-12`
+## Deploy
+
+1. Create a new app: `fly apps create docker-2022-06-13`
+1. Create a volume in a region of your choice: `fly volumes create data --size 50 --region iad`
 1. Deploy app: `fly deploy`
+
 
 ## Test
 
-1. Create a WireGuard peer with `fly wireguard create`
-1. Setup WireGuard with generated config
-1. `fly ips private` to get the IP of your Daemon
-1. Set the `DOCKER_HOST` env variable using that IP:
+1. Create a WireGuard peer: `fly wireguard create changelog iad github-actions-2022-06-13`
+1. [Setup WireGuard with generated config](https://fly.io/docs/reference/private-networking/#importing-your-tunnel)
+1. Get the Docker Engine private IP: `fly ips private` → `fdaa:0:4556:a7b:21e0:1:1f9d:2`
+1. Set the `DOCKER_HOST` env variable:
+    ```sh
+    export DOCKER_HOST=tcp://[fdaa:0:4556:a7b:21e0:1:1f9d:2]:2375
     ```
-    export DOCKER_HOST=tcp://[fdaa:0:5d2:a7b:81:0:26d4:2]:2375
+1. Ensure that you can connect to this Docker Engine:
+    ```sh
+    docker info
+
+    Client:
+     ...
+
+    Server:
+     ...
+     Server Version: 20.10.17
+     Kernel Version: 5.12.2
+     Operating System: Alpine Linux v3.16
+     Architecture: x86_64
+     CPUs: 1
+     Total Memory: 221.2MiB
+     Docker Root Dir: /data/docker
+
+    WARNING: API is accessible on http://[::]:2375 without encryption.
+             Access to the remote API is equivalent to root access on the host. Refer
+             to the 'Docker daemon attack surface' section in the documentation for
+             more information: https://docs.docker.com/go/attack-surface/
     ```
 
-# Scale
 
-1. You probably want to scale your remote Daemon: `fly scale vm dedicated-cpu-2x`
+## Scale
+
+We want to scale this remote Docker Engine to a size which is more appropriate for compiling Erlang code: `fly scale vm dedicated-cpu-4x`
+
+The above VM size takes `5m 25s` to complete a build with no cache. The default VM size takes ~3x as long.
 
 Other VM sizes available: https://fly.io/docs/about/pricing/
+
+
+## Use
+
+This new Docker Engine is configured & used in `.github/workflows/prod_image.yml`

--- a/2022.fly/docker/README.md
+++ b/2022.fly/docker/README.md
@@ -1,0 +1,25 @@
+# Fly Docker Daemon
+
+This is a Docker Daemon that runs on Fly.io and is used for https://github.com/thechangelog/changelog.com builds primarily.
+
+## Install
+
+1. Create a volume in a region of your choice: `fly volumes create data --size 20 --region iad`
+1. Create a new app: `fly apps create docker-2022-06-12`
+1. Deploy app: `fly deploy`
+
+## Test
+
+1. Create a WireGuard peer with `fly wireguard create`
+1. Setup WireGuard with generated config
+1. `fly ips private` to get the IP of your Daemon
+1. Set the `DOCKER_HOST` env variable using that IP:
+    ```
+    export DOCKER_HOST=tcp://[fdaa:0:5d2:a7b:81:0:26d4:2]:2375
+    ```
+
+# Scale
+
+1. You probably want to scale your remote Daemon: `fly scale vm dedicated-cpu-2x`
+
+Other VM sizes available: https://fly.io/docs/about/pricing/

--- a/2022.fly/docker/docker-entrypoint.d/docker
+++ b/2022.fly/docker/docker-entrypoint.d/docker
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+echo "Setting up Docker data directory"
+mkdir -p /data/docker
+
+echo "Configuring ipv6 for Docker"
+ip6tables -t nat -A POSTROUTING -s 2001:db8:1::/64 ! -o docker0 -j MASQUERADE
+
+echo "Done setting up Docker!"

--- a/2022.fly/docker/docker-entrypoint.d/sysctl
+++ b/2022.fly/docker/docker-entrypoint.d/sysctl
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+echo "Allowing ipv6 forwarding via sysctl"
+sysctl net.ipv6.conf.default.forwarding=1
+sysctl net.ipv6.conf.all.forwarding=1
+
+echo "General sysctl tweaks"
+sysctl vm.swappiness=0
+sysctl vm.dirty_ratio=6
+sysctl vm.dirty_background_ratio=3
+
+# Default Socket Receive Buffer
+sysctl net.core.rmem_default=31457280
+
+# Maximum Socket Receive Buffer
+sysctl net.core.rmem_max=33554432
+
+# Default Socket Send Buffer
+sysctl net.core.wmem_default=31457280
+
+# Maximum Socket Send Buffer
+sysctl net.core.wmem_max=33554432
+
+# Increase number of incoming connections
+sysctl net.core.somaxconn=65535
+
+# Increase number of incoming connections backlog
+sysctl net.core.netdev_max_backlog=65536
+
+# Increase the maximum amount of option memory buffers
+sysctl net.core.optmem_max=25165824
+
+# Increase the maximum total buffer-space allocatable
+# This is measured in units of pages (4096 bytes)
+sysctl "net.ipv4.tcp_mem=786432 1048576 26777216"
+sysctl "net.ipv4.udp_mem=65536 131072 262144"
+
+# Increase the read-buffer space allocatable
+sysctl "net.ipv4.tcp_rmem=8192 87380 33554432"
+sysctl net.ipv4.udp_rmem_min=16384
+
+# Increase the write-buffer-space allocatable
+sysctl "net.ipv4.tcp_wmem=8192 65536 33554432"
+sysctl net.ipv4.udp_wmem_min=16384

--- a/2022.fly/docker/entrypoint
+++ b/2022.fly/docker/entrypoint
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if [[ -d "docker-entrypoint.d" ]]
+then
+echo "Running docker-entrypoint.d files"
+/bin/run-parts docker-entrypoint.d
+fi
+
+echo "Running $@"
+
+exec "$@"

--- a/2022.fly/docker/etc/docker/daemon.json
+++ b/2022.fly/docker/etc/docker/daemon.json
@@ -1,0 +1,19 @@
+{
+    "data-root": "/data/docker",
+    "ipv6": true,
+    "fixed-cidr-v6": "2001:db8:1::/64",
+    "default-address-pools": [
+        {
+            "base": "10.100.0.1/16",
+            "size": 24
+        }
+    ],
+    "hosts": [
+        "unix:///var/run/docker.sock",
+        "tcp://[::]:2375"
+    ],
+    "mtu": 1400,
+    "max-concurrent-downloads": 10,
+    "max-concurrent-uploads": 5,
+    "metrics-addr": "0.0.0.0:9323"
+}

--- a/2022.fly/docker/fly.toml
+++ b/2022.fly/docker/fly.toml
@@ -1,0 +1,10 @@
+# Inspired by https://github.com/fly-apps/docker-daemon/blob/main/fly.toml
+# https://fly.io/docs/reference/configuration/
+
+app = "docker-2022-06-12"
+kill_signal = "SIGINT"
+kill_timeout = 30
+
+[[mounts]]
+  source = "data"
+  destination = "/data"

--- a/2022.fly/docker/fly.toml
+++ b/2022.fly/docker/fly.toml
@@ -1,7 +1,7 @@
 # Inspired by https://github.com/fly-apps/docker-daemon/blob/main/fly.toml
 # https://fly.io/docs/reference/configuration/
 
-app = "docker-2022-06-12"
+app = "docker-2022-06-13"
 kill_signal = "SIGINT"
 kill_timeout = 30
 


### PR DESCRIPTION
Before this, GitHub Actions was using a Docker Engine running on a bare metal host. We were connecting to it via Tailscale. This was OK as a stop-gap, but we ran into issues with:
- `TAILSCALE_AUTHKEY` max 90d TTL - [Generate auth key](https://login.tailscale.com/admin/settings/keys) +Reusable +Ephemeral
- `dagger-buildkitd` default container getting upgraded by a newer dagger CLI (I was using the same Docker Engine)
- `changelog_test_postgres` container failing to TCP port (another PostgreSQL was already running)

This introduces a dedicated Docker Engine running on Fly.io. It has a cache that persists between runs & is faster than the default GitHub Actions free runner (4 CPUs vs 2 CPUs). The PR includes:

- Upgrade fly cli to latest in 2022.fly
- Deploy Docker Engine on Fly.io
- Use Fly.io Docker Engine in prod_image workflow
- Only deploy the master branch

I am looking forward to use [Fly machines](https://fly.io/blog/fly-machines/) and spin up this Docker Engine... on the fly 🛫

https://fly.io/docs/reference/machines/

---

Thanks @mrkurt for https://github.com/fly-apps/docker-daemon - it really helped to get started with this!

For the full story, tune into [🎧 shipit.show/60](https://shipit.show/60)