### PR TITLE
Document what to do if the Wireguard tunnel stops working in GitHub Actions

### DIFF
--- a/2022.fly/docker/README.md
+++ b/2022.fly/docker/README.md
@@ -57,3 +57,26 @@ Other VM sizes available: https://fly.io/docs/about/pricing/
 ## Use
 
 This new Docker Engine is configured & used in `.github/workflows/prod_image.yml`
+
+## Troubleshooting
+
+### What should I do if the Wireguard tunnel stops working in GitHub Actions?
+
+1. Create a new WireGuard peer:
+    ```sh
+    pwd
+    $HOME/github.com/thechangelog/changelog.com/2022.fly/docker
+
+    fly wireguard create changelog iad github-actions-2022-08-30
+
+    !!!! WARNING: Output includes private key. Private keys cannot be recovered !!!!
+    !!!! after creating the peer; if you lose the key, you'll need to remove    !!!!
+    !!!! and re-add the peering connection.                                     !!!!
+    ? Filename to store WireGuard configuration in, or 'stdout':  stdout
+
+    [Interface]
+    # ... omitting for security reasons
+    PersistentKeepalive = 15
+    ```
+1. Update the [`FLY_WIREGUARD` value in GitHub Actions secrets](https://github.com/thechangelog/changelog.com/settings/secrets/actions) with the stdout output, starting with the `[Interface]` line
+1. Re-run the failed job, e.g. https://github.com/thechangelog/changelog.com/actions/runs/2951152698


### PR DESCRIPTION
Tried & tested. Merge if instructions are clear. I would recommend trying it
yourself before merging, but shortcuts also work 😉

Link to [README](https://github.com/thechangelog/changelog.com/tree/how-to-fix-wireguard-tunnel-in-github-actions/2022.fly/docker#what-should-i-do-if-the-wireguard-tunnel-stops-working-in-github-actions)