### PR TITLE
Upgrade Elixir from 1.12 to 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     working_directory: *dir
     docker:
       - image: *runtime
-      - image: circleci/postgres:12.6
+      - image: postgres:14.1
         environment:
           POSTGRES_USER: "postgres"
           POSTGRES_DB: changelog_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   deps:
     working_directory: &dir /app
     docker:
-      - image: &runtime thechangelog/runtime:2021-05-29T10.17.12Z
+      - image: &runtime thechangelog/runtime:2022-09-07T16.43.00Z
     steps:
       - checkout
       - restore_cache: &deps_cache

--- a/2021/dagger/prod_image/main.cue
+++ b/2021/dagger/prod_image/main.cue
@@ -22,8 +22,8 @@ git_sha:           dagger.#Input & {string}
 git_author:        dagger.#Input & {string}
 app_version:       dagger.#Input & {string}
 build_url:         dagger.#Input & {string}
-// ⚠️  Keep this in sync with manifests/changelog/db.yml
-test_db_image_ref:      dagger.#Input & {string | *"circleci/postgres:12.6"}
+// ⚠️  Keep this in sync with dev_docker/postgres.yml
+test_db_image_ref:      dagger.#Input & {string | *"postgres:14.1"}
 test_db_container_name: "changelog_test_postgres"
 
 // STORY #######################################################################

--- a/2021/dagger/prod_image/main.cue
+++ b/2021/dagger/prod_image/main.cue
@@ -14,7 +14,7 @@ docker_host:        dagger.#Input & {string}
 dockerhub_username: dagger.#Input & {string}
 dockerhub_password: dagger.#Input & {dagger.#Secret}
 // ⚠️  Keep this in sync with ../docker/Dockerfile.production
-runtime_image_ref: dagger.#Input & {string | *"thechangelog/runtime:2021-05-29T10.17.12Z"}
+runtime_image_ref: dagger.#Input & {string | *"thechangelog/runtime:2022-09-07T16.43.00Z"}
 build_version:     dagger.#Input & {string}
 git_branch:        dagger.#Input & {string | *"dev"}
 prod_image_ref:    dagger.#Input & {string | *"thechangelog/changelog.com:\(git_branch)"}

--- a/Makefile
+++ b/Makefile
@@ -280,19 +280,6 @@ publish-runtime-image: $(DOCKER)
 	$(DOCKER) push thechangelog/runtime:$(STACK_VERSION) && \
 	$(DOCKER) push thechangelog/runtime:latest
 
-.PHONY: howto-upgrade-elixir
-howto-upgrade-elixir:
-	@printf "$(BOLD)$(GREEN)All commands must be run in this directory. I propose a new side-by-side split to these instructions.$(NORMAL)\n\n"
-	@printf "Pick an image from $(BOLD)$(BLUE)https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy$(NORMAL)\n\n"
-	@printf "1/7. Update $(BOLD)docker/Dockerfile.runtime$(NORMAL) to use an image from the URL above, then run $(BOLD)make runtime-image$(NORMAL)\n" ; read -rp " $(DONE)" -n 1
-	@printf "2/7. Update $(BOLD)docker/Dockerfile.production$(NORMAL) to the exact runtime version that was published in the previous step\n" ; read -rp " $(DONE)" -n 1
-	@printf "3/7. Update $(BOLD).circleci/config.yml$(NORMAL) to the exact runtime version that was published in the previous step\n" ; read -rp " $(DONE)" -n 1
-	@printf "4/7. Update $(BOLD)2021/dagger/ci/ci.cue$(NORMAL) to the exact runtime version that was published in the previous step\n" ; read -rp " $(DONE)" -n 1
-	@printf "5/7. Update $(BOLD)dev_docker/changelog.yml$(NORMAL) to the exact runtime version that was published in the previous step\n" ; read -rp " $(DONE)" -n 1
-	@printf "6/7. Commit and push everything\n" ; read -rp " $(DONE)" -n 1
-	@printf "7/7. Watch the pipeline succeed and publish an app container image with the updated version of Elixir $(BOLD)$(BLUE)https://app.circleci.com/pipelines/github/thechangelog/changelog.com$(NORMAL)\n" ; read -rp " $(DONE)" -n 1
-	@printf "\nYou may want to update the elixir version in $(BOLD)mix.exs$(NORMAL)\n"
-
 APP_VERSION ?= $(shell date -u +'%y.%-m.%-d')
 export APP_VERSION
 

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ publish-runtime-image: $(DOCKER)
 .PHONY: howto-upgrade-elixir
 howto-upgrade-elixir:
 	@printf "$(BOLD)$(GREEN)All commands must be run in this directory. I propose a new side-by-side split to these instructions.$(NORMAL)\n\n"
-	@printf "Pick an image from $(BOLD)$(BLUE)https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-focal$(NORMAL)\n\n"
+	@printf "Pick an image from $(BOLD)$(BLUE)https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy$(NORMAL)\n\n"
 	@printf "1/7. Update $(BOLD)docker/Dockerfile.runtime$(NORMAL) to use an image from the URL above, then run $(BOLD)make runtime-image$(NORMAL)\n" ; read -rp " $(DONE)" -n 1
 	@printf "2/7. Update $(BOLD)docker/Dockerfile.production$(NORMAL) to the exact runtime version that was published in the previous step\n" ; read -rp " $(DONE)" -n 1
 	@printf "3/7. Update $(BOLD).circleci/config.yml$(NORMAL) to the exact runtime version that was published in the previous step\n" ; read -rp " $(DONE)" -n 1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the CMS behind [changelog.com](https://changelog.com). It's an [Elixir](
 
 ## Dependencies
 
-- Elixir 1.12
+- Elixir 1.13
 - Erlang/OTP 24
 
 ## Why is it open source?

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ Our thinking is: [make it work first, make it right next &amp; make it fast last
 Contributions to make changelog.com dev on Docker for Mac fast are welcome!
 It would be especially interesting to know if [ipvlan on macOS](https://github.com/docker/cli/blob/master/experimental/vlan-networks.md) makes things better.
 
+### How to upgrade Elixir?
+
+1. Pick an image from [hexpm/elixir](https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy)
+1. Update `docker/Dockerfile.runtime` to use an image from the URL above
+1. Run `make runtime-image` to publish the new container image
+1. Update `docker/Dockerfile.production` to the exact runtime version that was published in the previous step
+1. Update `.circleci/config.yml` to the exact runtime version used above
+1. Update `2021/dagger/prod_image/main.cue` to the exact runtime version used above
+1. Update `dev_docker/changelog.yml` to the exact runtime version used above
+1. Update the Elixir version in `README.md` & `mix.exs`
+1. Commit and push everything, then wait for the pipeline to deploy everything into production
+
+You may want to test everything locally by running `make dagger-prod-image` from within the `2021` dir. This makes it easy to debug any potential issues locally.
+
 ## Code of Conduct
 
 [Contributor Code of Conduct](https://changelog.com/coc). By participating in this project you agree to abide by its terms.

--- a/dev_docker/changelog.yml
+++ b/dev_docker/changelog.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   changelog_app:
-    image: thechangelog/runtime:2021-05-29T10.17.12Z
+    image: thechangelog/runtime:2022-09-07T16.43.00Z
     command: >
       /bin/sh -c 'apt-get update && apt-get install -y inotify-tools &&
       mix local.hex --force &&

--- a/dev_docker/postgres.yml
+++ b/dev_docker/postgres.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   postgres:
-    image: postgres:12.6
+    image: postgres:14.1
     ports:
       - '5432:5432'
     volumes:

--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -1,5 +1,5 @@
 FROM thechangelog/legacy_assets AS legacy_assets
-FROM thechangelog/runtime:2021-05-29T10.17.12Z
+FROM thechangelog/runtime:2022-09-07T16.43.00Z
 
 RUN mkdir /app
 ARG APP_FROM_PATH=.

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -2,8 +2,8 @@
 # FROM elixir:1.12
 #
 # @akoutmos recommends the hex.pm image because it's maintained by the hex core team
-# https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-focal
-FROM hexpm/elixir:1.12.0-erlang-24.0.1-ubuntu-focal-20210325
+# https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy
+FROM hexpm/elixir:1.13.4-erlang-24.3.4.4-ubuntu-jammy-20220428
 
 USER root
 

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -54,7 +54,7 @@ RUN echo "Install netcat for waiting on open ports..." \
 
 # https://nodejs.org/en/download/
 # https://github.com/nodejs/help/wiki/Installation#how-to-install-nodejs-via-binary-archive-on-linux
-ENV NODEJS_VERSION=v14.17.0
+ENV NODEJS_VERSION=v14.20.0
 ENV PATH=/usr/local/lib/nodejs/node-${NODEJS_VERSION}-linux-x64/bin:$PATH
 RUN echo "Install node.js ${NODEJS_VERSION}..." \
     ; ${FAIL_FAST_VERBOSE} \

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Changelog.Mixfile do
     [
       app: :changelog,
       version: System.get_env("APP_VERSION", "0.0.1"),
-      elixir: "~> 1.12",
+      elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Via [changelog.slack.com #dev](https://changelog.slack.com/archives/C03SA8VE2/p1662565738652659) @jerodsanto:

> how/can we get Elixir 1.13 on CI and prod? I used `Map.reject` not realizing it’s a newer feature…

I upgraded a few other related things as I was working in this area:
- Erlang as this is tied to Elixir
- Ubuntu container OS (we want the latest LTS)
- PostgreSQL (that's the version that we currently use in production)

I also moved the Elixir upgrade instructions into the `README.md` so that they are easier to find.