### PR TITLE
Bump from Elixir 1.13 to 1.14 (and OTP 24 to 25)

### DIFF
--- a/.dagger/env/prod_image/values.yaml
+++ b/.dagger/env/prod_image/values.yaml
@@ -42,11 +42,11 @@ inputs:
                 - _build
                 - dagger
     app_version:
-        text: 22.11.12+a15dd68f3a17e76d42930782ad24ddf769a87d87
+        text: 22.11.13+c84768a1d0df8afd6f8848d0100af252e85f6dc1
     build_url:
         text: https://github.com/thechangelog/changelog.com/actions
     build_version:
-        text: 22.11.12+a15dd68f3a17e76d42930782ad24ddf769a87d87
+        text: 22.11.13+c84768a1d0df8afd6f8848d0100af252e85f6dc1
     docker_host:
         text: tcp://100.81.87.121:2375
     dockerhub_password:
@@ -56,22 +56,22 @@ inputs:
     git_author:
         text: gerhard
     git_sha:
-        text: a15dd68f3a17e76d42930782ad24ddf769a87d87
+        text: c84768a1d0df8afd6f8848d0100af252e85f6dc1
     prod_dockerfile:
         text: |
             FROM thechangelog/legacy_assets AS legacy_assets
-            FROM thechangelog/runtime:2022-09-21T23.19.21Z
+            FROM thechangelog/runtime:2022-11-13T07.34.05Z
 
             RUN mkdir /app
             ARG APP_FROM_PATH=.
             COPY ${APP_FROM_PATH} /app
             WORKDIR /app
             RUN echo "Ensure deps are present & OK..." \
-                ; ls -lahd deps/*
+              ; ls -lahd deps/*
             RUN echo "Ensure prod bytecode is present & OK..." \
-                ; ls -lahd _build/prod/lib/*/ebin
+              ; ls -lahd _build/prod/lib/*/ebin
             RUN echo "Ensure prod static assets are present & OK..." \
-                ; ls -lah priv/static/cache_manifest.json
+              ; ls -lah priv/static/cache_manifest.json
 
             COPY --from=legacy_assets /var/www/wp-content /app/priv/wp-content
 
@@ -90,8 +90,8 @@ inputs:
             ENV BUILD_URL=${BUILD_URL}
             # Used by various tooling to report the identity & origin of this build
             RUN echo "$GIT_SHA" > priv/static/version.txt \
-                ; echo "$GIT_AUTHOR" > COMMIT_USER \
-                ; echo "$BUILD_URL" > priv/static/build.txt
+              ; echo "$GIT_AUTHOR" > COMMIT_USER \
+              ; echo "$BUILD_URL" > priv/static/build.txt
 
             EXPOSE 4000
 
@@ -111,8 +111,8 @@ sops:
             ZE8xQlF0bHVZejFHeEwzZXBwZnF3encK8DzznyIRG/Hq9PDpF52XFE1phXd5Cwcu
             aphxZYpkm6JiBQySohnqHYCdN0xjCJOXOHAGIdnoog94rnRGqbqrew==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-11-12T18:50:25Z"
-    mac: ENC[AES256_GCM,data:yF3OkSpxn/Mwf9aR1uGq+vevkCORYCgshsoqGkKhb1uBbOrV/F68xLu763hMQJp7UXAxqPZhlhfnlIkjfC+gbtS3OAJO5TtRxW1sy2j5CgpoYrMvaxFxwtBTEtrbGMleK1XI7zwxKpS5oTRLMSj4HlftCrflV+123jIQpHmi39s=,iv:Ls48/AlvN4oY/p/0BPCr323VFVDNOoeTh50hGZMRRjM=,tag:mLicnRAiBOGeNKqoVP86xg==,type:str]
+    lastmodified: "2022-11-13T07:51:43Z"
+    mac: ENC[AES256_GCM,data:4skxsEcznFxigZ2yLOtxAxxo5CRmiZwMxZxBJzy6Xe0QV9RKgGGLswEIXyYx1XE0H35D7BEm4qKX/eqCd6ZNCP6X1hGvqW4wR3jOPinCpxj5cTeYLtqvdPE3eYYP9WztLwpw/ndion9LjV+1Hdnes3fL9IPkMgpW9hOTe39PME4=,iv:agqCrcoIQUYpmdLRsPj6u8ZA/+GlNhyn4dR12+gcoyI=,tag:931vmINorFrYNjvXJHfOMg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/2021/dagger/prod_image/main.cue
+++ b/2021/dagger/prod_image/main.cue
@@ -12,7 +12,7 @@ docker_host:        dagger.#Input & {string}
 dockerhub_username: dagger.#Input & {string}
 dockerhub_password: dagger.#Input & {dagger.#Secret}
 // ⚠️  Keep this in sync with ../docker/production.Dockerfile
-runtime_image_ref: dagger.#Input & {string | *"thechangelog/runtime:UPDATE_ONCE_PUBLISHED"}
+runtime_image_ref: dagger.#Input & {string | *"thechangelog/runtime:2022-11-13T07.34.05Z"}
 build_version:     dagger.#Input & {string}
 git_branch:        dagger.#Input & {string | *"dev"}
 prod_image_ref:    dagger.#Input & {string | *"thechangelog/changelog.com:\(git_branch)"}

--- a/2021/dagger/prod_image/main.cue
+++ b/2021/dagger/prod_image/main.cue
@@ -12,7 +12,7 @@ docker_host:        dagger.#Input & {string}
 dockerhub_username: dagger.#Input & {string}
 dockerhub_password: dagger.#Input & {dagger.#Secret}
 // ⚠️  Keep this in sync with ../docker/production.Dockerfile
-runtime_image_ref: dagger.#Input & {string | *"thechangelog/runtime:2022-09-21T23.19.21Z"}
+runtime_image_ref: dagger.#Input & {string | *"thechangelog/runtime:UPDATE_ONCE_PUBLISHED"}
 build_version:     dagger.#Input & {string}
 git_branch:        dagger.#Input & {string | *"dev"}
 prod_image_ref:    dagger.#Input & {string | *"thechangelog/changelog.com:\(git_branch)"}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is the CMS behind [changelog.com](https://changelog.com). It's an [Elixir](
 
 ## Dependencies
 
-- Elixir 1.13
-- Erlang/OTP 24
+- Elixir 1.14
+- Erlang/OTP 25
 
 ## Why is it open source?
 
@@ -105,13 +105,16 @@ You can now start the app normally, all changelog.com content at the time the db
 ### How to upgrade Elixir?
 
 1. Pick an image from [hexpm/elixir](https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy)
-1. Update `docker/Dockerfile.runtime` to use an image from the URL above
-1. Run `make runtime-image` to publish the new container image
-1. Update `docker/Dockerfile.production` to the exact runtime version that was published in the previous step
-1. Update `2021/dagger/prod_image/main.cue` to the exact runtime version used above
-1. Update `dev_docker/changelog.yml` to the exact runtime version used above
-1. Update the Elixir version in `README.md` & `mix.exs`
-1. Commit and push everything, then wait for the pipeline to deploy everything into production
+2. Update `docker/Dockerfile.runtime` to use the image with the desired version from the URL above
+3. Run `make runtime-image` to publish the new container image, which will look something like: `thechangelog/runtime:DATE_TIME`
+   1. This will require push access to [the Docker Hub org](https://hub.docker.com/r/thechangelog/runtime/tags), which only maintainers will have; you'll need to request an image publish from them once the rest of your PR is ready.
+   2. Update the following files with this new runtime version:
+      1. `docker/Dockerfile.production`
+      2. `2021/dagger/prod_image/main.cue`
+         1. Do not worry that the directory refers to `2021`; it is still used.
+      3. `dev_docker/changelog.yml`
+4. Update the Elixir version in `README.md` & `mix.exs`
+5. Commit and push everything, then wait for the pipeline to deploy everything into production
 
 You may want to test everything locally by running `make ship-it` from within the `2021` dir. This makes it easy to debug any potential issues locally.
 

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ You can now start the app normally, all changelog.com content at the time the db
 ### How to upgrade Elixir?
 
 1. Pick an image from [hexpm/elixir](https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy)
-2. Update `docker/Dockerfile.runtime` to use the image with the desired version from the URL above
+2. Update `docker/runtime.Dockerfile` to use the image with the desired version from the URL above
 3. Run `make runtime-image` to publish the new container image, which will look something like: `thechangelog/runtime:DATE_TIME`
-   1. This will require push access to [the Docker Hub org](https://hub.docker.com/r/thechangelog/runtime/tags), which only maintainers will have; you'll need to request an image publish from them once the rest of your PR is ready.
+   1. This will require push access to [the Docker Hub `thechangelog` org](https://hub.docker.com/r/thechangelog/runtime/tags), which only maintainers will have (💡 `changeloci` in 1Password); you'll need to request an image publish from them once the rest of your PR is ready.
    2. Update the following files with this new runtime version:
-      1. `docker/Dockerfile.production`
+      1. `docker/production.Dockerfile`
       2. `2021/dagger/prod_image/main.cue`
          1. Do not worry that the directory refers to `2021`; it is still used.
       3. `dev_docker/changelog.yml`

--- a/dev_docker/changelog.yml
+++ b/dev_docker/changelog.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   changelog_app:
-    image: thechangelog/runtime:2022-09-21T23.19.21Z
+    image: thechangelog/runtime:UPDATE_ONCE_PUBLISHED
     command: >
       /bin/sh -c 'apt-get update && apt-get install -y inotify-tools &&
       mix local.hex --force &&

--- a/dev_docker/changelog.yml
+++ b/dev_docker/changelog.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   changelog_app:
-    image: thechangelog/runtime:UPDATE_ONCE_PUBLISHED
+    image: thechangelog/runtime:2022-11-13T07.34.05Z
     command: >
       /bin/sh -c 'apt-get update && apt-get install -y inotify-tools &&
       mix local.hex --force &&

--- a/docker/production.Dockerfile
+++ b/docker/production.Dockerfile
@@ -6,11 +6,11 @@ ARG APP_FROM_PATH=.
 COPY ${APP_FROM_PATH} /app
 WORKDIR /app
 RUN echo "Ensure deps are present & OK..." \
-    ; ls -lahd deps/*
+  ; ls -lahd deps/*
 RUN echo "Ensure prod bytecode is present & OK..." \
-    ; ls -lahd _build/prod/lib/*/ebin
+  ; ls -lahd _build/prod/lib/*/ebin
 RUN echo "Ensure prod static assets are present & OK..." \
-    ; ls -lah priv/static/cache_manifest.json
+  ; ls -lah priv/static/cache_manifest.json
 
 COPY --from=legacy_assets /var/www/wp-content /app/priv/wp-content
 
@@ -29,8 +29,8 @@ ARG BUILD_URL
 ENV BUILD_URL=${BUILD_URL}
 # Used by various tooling to report the identity & origin of this build
 RUN echo "$GIT_SHA" > priv/static/version.txt \
-    ; echo "$GIT_AUTHOR" > COMMIT_USER \
-    ; echo "$BUILD_URL" > priv/static/build.txt
+  ; echo "$GIT_AUTHOR" > COMMIT_USER \
+  ; echo "$BUILD_URL" > priv/static/build.txt
 
 EXPOSE 4000
 

--- a/docker/production.Dockerfile
+++ b/docker/production.Dockerfile
@@ -1,5 +1,5 @@
 FROM thechangelog/legacy_assets AS legacy_assets
-FROM thechangelog/runtime:UPDATE_ONCE_PUBLISHED
+FROM thechangelog/runtime:2022-11-13T07.34.05Z
 
 RUN mkdir /app
 ARG APP_FROM_PATH=.

--- a/docker/production.Dockerfile
+++ b/docker/production.Dockerfile
@@ -1,5 +1,5 @@
 FROM thechangelog/legacy_assets AS legacy_assets
-FROM thechangelog/runtime:2022-09-21T23.19.21Z
+FROM thechangelog/runtime:UPDATE_ONCE_PUBLISHED
 
 RUN mkdir /app
 ARG APP_FROM_PATH=.

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -46,7 +46,7 @@ RUN echo "Install netcat for waiting on open ports..." \
 
 # https://nodejs.org/en/download/releases/
 # https://github.com/nodejs/help/wiki/Installation#how-to-install-nodejs-via-binary-archive-on-linux
-ENV NODEJS_VERSION=v14.20.0
+ENV NODEJS_VERSION=v14.21.1
 ENV PATH=/usr/local/lib/nodejs/node-${NODEJS_VERSION}-linux-x64/bin:$PATH
 RUN echo "Install node.js ${NODEJS_VERSION}..." \
     ; ${FAIL_FAST_VERBOSE} \

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -1,6 +1,6 @@
 # @akoutmos recommends the hex.pm image because it's maintained by the hex core team
 # https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy
-FROM hexpm/elixir:1.14.0-erlang-25.1-ubuntu-jammy-20220428
+FROM hexpm/elixir:1.14.2-erlang-25.1-ubuntu-jammy-20220428
 
 USER root
 

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -1,6 +1,6 @@
 # @akoutmos recommends the hex.pm image because it's maintained by the hex core team
 # https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy
-FROM hexpm/elixir:1.13.4-erlang-24.3.4.5-ubuntu-jammy-20220428
+FROM hexpm/elixir:1.14.0-erlang-25.1-ubuntu-jammy-20220428
 
 USER root
 

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -12,55 +12,55 @@ ARG PKG_INSTALL="apt-get install --yes"
 ENV TERM=xterm-256color
 
 RUN echo "Pre-warm package manager cache..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; apt-get update
+  ; ${FAIL_FAST_VERBOSE} \
+  ; apt-get update
 
 RUN echo "Install convert (imagemagick), required for image resizing..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; ${PKG_INSTALL} imagemagick \
-    ; convert --version
+  ; ${FAIL_FAST_VERBOSE} \
+  ; ${PKG_INSTALL} imagemagick \
+  ; convert --version
 
 RUN echo "Install curl..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; ${PKG_INSTALL} curl ca-certificates \
-    ; curl --version
+  ; ${FAIL_FAST_VERBOSE} \
+  ; ${PKG_INSTALL} curl ca-certificates \
+  ; curl --version
 
 RUN echo "Install git..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; ${PKG_INSTALL} git \
-    ; git --version
+  ; ${FAIL_FAST_VERBOSE} \
+  ; ${PKG_INSTALL} git \
+  ; git --version
 
 RUN echo "Install make..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; ${PKG_INSTALL} make \
-    ; make --version
+  ; ${FAIL_FAST_VERBOSE} \
+  ; ${PKG_INSTALL} make \
+  ; make --version
 
 RUN echo "Install build-essential for gcc, required by cmark..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; ${PKG_INSTALL} build-essential \
-    ; gcc --version
+  ; ${FAIL_FAST_VERBOSE} \
+  ; ${PKG_INSTALL} build-essential \
+  ; gcc --version
 
 RUN echo "Install netcat for waiting on open ports..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; ${PKG_INSTALL} netcat
+  ; ${FAIL_FAST_VERBOSE} \
+  ; ${PKG_INSTALL} netcat
 
 # https://nodejs.org/en/download/releases/
 # https://github.com/nodejs/help/wiki/Installation#how-to-install-nodejs-via-binary-archive-on-linux
 ENV NODEJS_VERSION=v14.21.1
 ENV PATH=/usr/local/lib/nodejs/node-${NODEJS_VERSION}-linux-x64/bin:$PATH
 RUN echo "Install node.js ${NODEJS_VERSION}..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; ${PKG_INSTALL} xz-utils ; xz --version \
-    ; mkdir -p /usr/local/lib/nodejs \
-    ; curl --silent --fail --location --output node-${NODEJS_VERSION}-linux-x64.tar.xz https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}-linux-x64.tar.xz \
-    ; tar -xJvf node-${NODEJS_VERSION}-linux-x64.tar.xz -C /usr/local/lib/nodejs \
-    ; node --version \
-    ; rm node-${NODEJS_VERSION}-linux-x64.tar.xz
+  ; ${FAIL_FAST_VERBOSE} \
+  ; ${PKG_INSTALL} xz-utils ; xz --version \
+  ; mkdir -p /usr/local/lib/nodejs \
+  ; curl --silent --fail --location --output node-${NODEJS_VERSION}-linux-x64.tar.xz https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}-linux-x64.tar.xz \
+  ; tar -xJvf node-${NODEJS_VERSION}-linux-x64.tar.xz -C /usr/local/lib/nodejs \
+  ; node --version \
+  ; rm node-${NODEJS_VERSION}-linux-x64.tar.xz
 
 RUN echo "Install yarn..." \
-    ; ${FAIL_FAST_VERBOSE} \
-    ; npm install -g yarn \
-    ; yarn --version
+  ; ${FAIL_FAST_VERBOSE} \
+  ; npm install -g yarn \
+  ; yarn --version
 
 RUN mix local.rebar --force
 RUN mix local.hex --force

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Changelog.Mixfile do
     [
       app: :changelog,
       version: System.get_env("APP_VERSION", "0.0.1"),
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Addresses https://github.com/thechangelog/changelog.com/issues/427

Note: You will have to `rm -rf ./build ./deps` before attempting to run this with 1.14. After that:
```
❯ mix test

19:51:36.464 [info] Migrations already up
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 18.5 seconds (2.3s async, 16.2s sync)
2 doctests, 894 tests, 0 failures
```

I don't have permissions to publish the updated Docker image, but I figured I'd at least do all of the other steps. 😄 

On a related note, I think it'd be worth removing `.tool-versions` from the `.gitignore`, as it would automatically use the correct Elixir version for anyone who uses `asdf`. 😅