### PR TITLE
Increase connections limit for our Fly.io app instance

### DIFF
--- a/2022.fly/fly.toml
+++ b/2022.fly/fly.toml
@@ -5,39 +5,39 @@ kill_signal = "SIGTERM"
 kill_timeout = 5
 
 [build]
-  image = "thechangelog/changelog.com:master"
+image = "thechangelog/changelog.com:master"
 
 [deploy]
-  strategy = "bluegreen"
+strategy = "bluegreen"
 
 [env]
-  AWS_ASSETS_BUCKET = "changelog-assets"
-  AWS_REGION = "us-east-1"
-  AWS_UPLOADS_HOST = "https://changelog-assets.s3.amazonaws.com"
-  GRAFANA_DATASOURCE_ID = "grafanacloud-changelog-prom"
-  GRAFANA_URL = "https://changelog.grafana.net"
-  PORT = "4000"
-  STATIC_URL_HOST = "cdn.changelog.com"
-  URL_HOST = "changelog.com"
+AWS_ASSETS_BUCKET = "changelog-assets"
+AWS_REGION = "us-east-1"
+AWS_UPLOADS_HOST = "https://changelog-assets.s3.amazonaws.com"
+GRAFANA_DATASOURCE_ID = "grafanacloud-changelog-prom"
+GRAFANA_URL = "https://changelog.grafana.net"
+PORT = "4000"
+STATIC_URL_HOST = "cdn.changelog.com"
+URL_HOST = "changelog.com"
 
 [[services]]
-  internal_port = 4000
-  processes = ["app"]
-  protocol = "tcp"
+internal_port = 4000
+processes = ["app"]
+protocol = "tcp"
 
-  [[services.http_checks]]
-    grace_period = "120s"
-    interval = 15000
-    method = "get"
-    path = "/health"
-    protocol = "http"
-    timeout = 10000
+[[services.http_checks]]
+grace_period = "120s"
+interval = 15000
+method = "get"
+path = "/health"
+protocol = "http"
+timeout = 10000
 
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
+[[services.ports]]
+handlers = ["tls", "http"]
+port = 443
 
-  [[services.ports]]
-    handlers = ["http"]
-    port = "80"
-    force_https = true
+[[services.ports]]
+handlers = ["http"]
+port = "80"
+force_https = true

--- a/2022.fly/fly.toml
+++ b/2022.fly/fly.toml
@@ -1,4 +1,5 @@
 # Inspired by https://github.com/fly-apps/live_beats/blob/master/fly.toml
+# Full app config reference: https://fly.io/docs/reference/configuration/
 app = "changelog-2022-03-13"
 
 kill_signal = "SIGTERM"
@@ -41,3 +42,11 @@ port = 443
 handlers = ["http"]
 port = "80"
 force_https = true
+
+# Increase the limit of connections that a single app instance can handle
+# Otherwise Fly proxy will start sending the requests to instances that we don't have... yet
+# Related to https://github.com/thechangelog/changelog.com/issues/424
+[services.concurrency]
+hard_limit = 2500
+soft_limit = 2000
+type = "connections"


### PR DESCRIPTION
~18:50 UTC time Pingdom started reporting `Socket timeout, unable to connect to server` for our Fly.io app instance:

<a href="https://my.pingdom.com/reports/uptime#check=11105681&daterange=1days&tab=uptime_tab&checkName=changelog-2022-03-13.fly.dev"><img width="1272" alt="image" src="https://user-images.githubusercontent.com/3342/197418929-f155eaaf-17ba-49f5-a4e8-081acc1517cb.png"></a>

<a href="https://my.pingdom.com/app/uptime/11105681/root-cause-analysis/1286900209"><img width="801" alt="image" src="https://user-images.githubusercontent.com/3342/197418972-edd5d1c7-1994-4489-bf6b-79d6599246c7.png"></a>

On closer inspection, the app instance [hit the default `25` connections limit](https://fly.io/docs/reference/configuration/#services-concurrency):

[![image](https://user-images.githubusercontent.com/3342/197419463-7f0a0ee5-2bf0-4a4a-a6d2-97f6e851fe7d.png)](https://fly-metrics.net/d/fly-app/fly-app?orgId=23559&from=1666546656028&to=1666558998886&viewPanel=1)

As a result, the app instance stopped accepting any new connections, and therefore serving any traffic:

<a href="https://fly-metrics.net/d/fly-app/fly-app?orgId=23559&from=1666546656028&to=1666558998886&viewPanel=7"><img width="1430" alt="image" src="https://user-images.githubusercontent.com/3342/197419507-fe1cda56-2b36-4d1c-9095-41f94bf85b70.png"></a>

This is peculiar, since everything looked normal from the CDN (Fastly) perspective:

<a href="https://ui.honeycomb.io/changelog/datasets/fastly/result/BDvFEVvG9ed?useUTCXAxis"><img width="1332" alt="image" src="https://user-images.githubusercontent.com/3342/197419581-e1dca483-21ae-4272-9b24-82a068e02452.png"></a>

Anyhow, `25` concurrent connections is a super low limit and it was obvious that we needed to bump it up. That's what this PR does. FTR, the change has been already applied via `fly deploy`.

Notice the app concurrency:
- after this change was rolled out @ 19:50
- number of connections growing linearly to > 450 over the span of 1h
- the app concurrency resetting itself to a normal level afterwards

<a href="https://fly-metrics.net/d/fly-app/fly-app?orgId=23559&from=1666540641162&to=1666562191123&viewPanel=1"><img width="1430" alt="image" src="https://user-images.githubusercontent.com/3342/197420133-f16921cf-af9c-454d-9bec-fa2f86b8a2d0.png"></a>

While there was a secondary smaller spike (maxed out at 15 connections), it was nothing like what happened previously. Neither https://status.fastly.com/, nor https://status.flyio.net/ show any incident during this period. I am wondering what metrics/logs are we missing to figure out whether:

1. This was a Fastly issue, maybe keeping connections open for longer than they needed to
2. This was a Fly issue, where connections were not being terminate properly
3. A mix of both 🤷‍♂️

```mermaid
flowchart LR

A[Fastly CDN] --> |TCP| B{Fly Proxy}
B --> |TCP| C(Phoenix app instance)
```

WDYT @mrkurt?

If this looks good to you @jerodsanto, ship it!