### PR TITLE
Add dev container (thus codespaces) support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "dockerComposeFile": ["docker-compose.yml"],
+  "workspaceFolder": "/workspace",
+  "service": "devcontainer",
+  "forwardPorts": [
+    4000,
+    5432
+  ],
+  "extensions": [
+    "JakeBecker.elixir-ls"
+  ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  devcontainer:
+    build:
+      context: ../
+      dockerfile: docker/runtime.Dockerfile
+    volumes:
+      - ../:/workspace
+    network_mode: service:db
+
+    # Installs "inotify-tools" to facilitate dynamic reloads of the website when changes are made and
+    # "postgresql-client" to connect to the container running postgres (on localhost:5432) if postgres commands are needed.
+    # Afterwards, sleeps forever so things don't shut down after the process ends.
+    command: >
+      bash -c "apt-get install --yes inotify-tools
+      && apt-get install --yes postgresql-client
+      && sleep infinity"
+
+  db:
+    image: postgres:14.6
+    ports:
+      - "4000:4000"
+      - "5432:5432"
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgressql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: changelog_dev
+
+volumes:
+  postgres-data:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,3 +181,32 @@ Server:
 ```
 
 Any `docker` commands will now run against this remote Docker Engine now, including `make runtime-image`.
+
+## Using GitHub Codespaces
+
+A pre-configured Codespace can be launched for this repo by following the instructions [here](https://docs.github.com/codespaces/developing-in-codespaces/creating-a-codespace-for-a-repository). Everything you need to start contributing is installed and the following commands will start the site:
+
+```console
+# CONFIGURE APP
+mix deps.get
+mix ecto.setup
+
+# CONFIGURE STATIC ASSETS
+cd assets
+yarn install
+
+# RUN APP
+mix phx.server
+```
+
+### Codespaces + VS Code Web Editor
+
+If you are developing in the VS Code web editor two extra steps are required for the site to be able to load static assets correctly. Port forwarding utilizes a dynamic HTTPS `*.preview.app.github.dev` URL when developing in the web editor.
+
+1. Set the `CODESPACES_WEB` environment variable. This tells the app to construct appropriate static asset paths.
+
+   ```console
+   export CODESPACES_WEB=true
+   ```
+
+2. After running the app the URL it is exposed on is visible in the `Toggle Ports` VS Code view (port 4000). Launch that URL and configure your browser to allow it to load insecure content via the instructions [here](https://experienceleague.adobe.com/docs/target/using/experiences/vec/troubleshoot-composer/mixed-content.html). This is necessary to allow js/css to be accessible over HTTP when the `*.preview.app.github.dev` site is using HTTPS.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,8 @@
 import Config
 
+port = 4000
 config :changelog, ChangelogWeb.Endpoint,
-  http: [port: 4000],
+  http: [port: port],
   url: [host: System.get_env("HOST", "localhost")],
   check_origin: false,
   static_url: [path: "/static"],
@@ -12,6 +13,17 @@ config :changelog, ChangelogWeb.Endpoint,
   watchers: [
     yarn: ["start", cd: Path.expand("../assets", __DIR__)]
   ]
+
+# Update the static_url config if running inside a GitHub Codespaces VS Code web editor to allow assets
+# to load when viewing the forwarded port's URL.
+# "CODESPACES_WEB" is manually set by devs, the other env vars are set by Codespaces automatically
+# https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace
+if System.get_env("CODESPACES_WEB") do
+  codespaces_host = "#{System.get_env("CODESPACE_NAME")}-#{port}.#{System.get_env("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")}"
+
+  config :changelog, ChangelogWeb.Endpoint,
+    static_url: [host: codespaces_host, path: "/static", port: 80]
+end
 
 # Live reloading is opt-in
 if System.get_env("LIVE_RELOAD") do


### PR DESCRIPTION
Adds a [devcontainer](https://containers.dev/) spec that can be used to spin up a full Changelog development environment in a local container or in Github Codespaces.

Two containers are started (using docker compose).  The first (devcontainer) includes everything in [runtime.Dockerfile](https://github.com/thechangelog/changelog.com/blob/master/docker/runtime.Dockerfile) and is the container you land in. The second container contains Postgres.

Once the Codespace is started you start the Contributing.md instructions at the `# CONFIGURE APP` section and no additional setup is required. The app launches and is accessible at `localhost:4000` in a local browser and all tests pass.