### PR TITLE
Raise error on sign-up if user already exists

### DIFF
--- a/lib/changelog_web/controllers/person_controller.ex
+++ b/lib/changelog_web/controllers/person_controller.ex
@@ -36,8 +36,14 @@ defmodule ChangelogWeb.PersonController do
     email = Map.get(person_params, "email")
 
     if Captcha.verify(captcha) do
-      if person = Repo.get_by(Person, email: email) do
-        welcome_community(conn, person)
+      if _person = Repo.get_by(Person, email: email) do
+        # If the person's email already existed in the DB it isn't safe to update profile info until they have signed in.
+        # Don't populate the form with the existing person's details when returning the error.
+        changeset = Person.insert_changeset(%Person{}, person_params)
+
+        conn
+        |> put_flash(:error, "Member exists with that email address. Please sign in.")
+        |> render(:join, changeset: changeset, person: nil)
       else
         changeset = Person.insert_changeset(%Person{public_profile: false}, person_params)
 


### PR DESCRIPTION
There is a confusing flow where a "fake" user gets created in the DB when a user signs up for the newsletter.  If they then sign up for the site afterwards their profile info they fill out during the sign-up will be silently dropped (see #438 for more info).

The sign-up flow should error if the e-mail already exists in the DB instead and direct the user to sign in. A more optimal user experience would validate the e-mail immediately when the field is populated on the form and assist them in signing in but this flow should be rare enough to not warrant the effort.