### PR TITLE
Use new runtime image in devcontainer - instead of runtime.Dockerfile

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.8'
 
 services:
   devcontainer:
-    build:
-      context: ../
-      dockerfile: docker/runtime.Dockerfile
+    image: thechangelog/runtime:2022-11-13T07.34.05Z
     volumes:
       - ../:/workspace
     network_mode: service:db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ mix test
       1. `docker/production.Dockerfile`
       2. `2021/dagger/prod_image/main.cue`
          1. Do not worry that the directory refers to `2021`; it is still used.
-      3. `dev_docker/changelog.yml`
+      3. `.devcontainer/docker-compose.yml`
 4. Update the Elixir version in `README.md` & `mix.exs`
 5. Commit and push everything, then wait for the pipeline to deploy everything into production
 


### PR DESCRIPTION
So that contributors are not to forced for everything to build from scratch. We are also thinking of improving on those Dockerfiles so that we can make better use of op caching. All of it can be captured as code that will be used as one big CI/CD pipeline, with sweet caching.

This is a follow-up to https://github.com/thechangelog/changelog.com/pull/437