### PR TITLE
Add new caching variant for multi-node clustering

### DIFF
--- a/lib/cache2.ex
+++ b/lib/cache2.ex
@@ -1,0 +1,51 @@
+defmodule Changelog.Cache2 do
+  use GenServer
+
+  @table_name :the_cache
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl true
+  def init(nil) do
+    :ets.new(@table_name, [:named_table, :public])
+    ref = subscribe()
+
+    {:ok, %{ref: ref}}
+  end
+
+  defp subscribe do
+    # TODO: Can be replace with Phoenix.PubSub.subscribe later, or now
+    {:ok, listen_ref} = Postgrex.Notifications.listen(Changelog.PostgresNotifications, "cache_clears")
+    listen_ref
+  end
+
+  def clear_all(key) do
+    # TODO: Can be replace with Phoenix.PubSub.broadcast later, or now
+    Ecto.Adapters.SQL.query(Changelog.Repo, "NOTIFY cache_clears, '#{key}'", [])
+  end
+
+  def set(key, data) do
+    :ets.insert(@table_name, {key, data})
+  end
+
+  def get(key) do
+    result = :ets.lookup(@table_name, key)
+    case result do
+      [] -> nil
+      [{_key, value}] -> value
+    end
+  end
+
+  def clear(key) do
+    :ets.delete(@table_name, key)
+  end
+
+  @impl true
+  def handle_info({:notification, _notification_pid, _listen_ref, "cache_clears", key}, state) do
+    IO.inspect(key, label: "clearing")
+    clear(key)
+    {:noreply, state}
+  end
+end

--- a/lib/cache2.ex
+++ b/lib/cache2.ex
@@ -1,10 +1,32 @@
 defmodule Changelog.Cache2 do
+  @moduledoc """
+  This cache implementation is a basic way of keeping cached feeds in memory
+  and working around the Changelog app not yet being clustered.
+
+  The cache is updated and coordinated in a simplistic and naive way which
+  should be sufficient as any missing cached item should be re-generated
+  on request and any stale items should be replaced on the next update or
+  when a listener complains.
+
+  Nodes coming and going can easily place this out of phase but it should
+  be within reason for the application's needs.
+
+  We pass a message to all nodes when `clear_all/1` is called and similarly
+  when `set_all/2` is called.
+
+  This entire implementation would be straight-forward over Phoenix PubSub
+  if we had Redis or clustering. Now we'll use Postgres LISTEN/NOTIFY instead.
+  Fun!
+  """
   use GenServer
+  require Logger
 
   @table_name :the_cache
+  @postgres_notify_payload_limit 8000
 
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  def start_link(args) do
+    name = args[:name] || __MODULE__
+    GenServer.start_link(__MODULE__, nil, name: name)
   end
 
   @impl true
@@ -16,36 +38,95 @@ defmodule Changelog.Cache2 do
   end
 
   defp subscribe do
-    # TODO: Can be replace with Phoenix.PubSub.subscribe later, or now
-    {:ok, listen_ref} = Postgrex.Notifications.listen(Changelog.PostgresNotifications, "cache_clears")
+    {:ok, listen_ref} =
+      Postgrex.Notifications.listen(Changelog.PostgresNotifications, "cache_ops")
+
     listen_ref
   end
 
   def clear_all(key) do
-    # TODO: Can be replace with Phoenix.PubSub.broadcast later, or now
-    Ecto.Adapters.SQL.query(Changelog.Repo, "NOTIFY cache_clears, '#{key}'", [])
+    Ecto.Adapters.SQL.query(Changelog.Repo, "NOTIFY cache_ops, 'clear:#{key}'", [])
   end
 
-  def set(key, data) do
-    :ets.insert(@table_name, {key, data})
+  @doc """
+  This function takes a key and an MFA which is a tuple of
+  `{module, function, arguments}` which will be used to create
+  a value on every node running the cache. We don't just send
+  the data because it won't fit the NOTIFY/LISTEN mechanism
+  and is rather large for passing around willy-nilly regardless.
+  So each node gets to generate their own data. Your code is deterministic,
+  right Jerod?
+  """
+  def set_all(key, {module, function, arguments}) do
+    result = apply(module, function, arguments)
+    set(key, result)
+
+    item = term_to_postgres_string!({key, module, function, arguments})
+    Ecto.Adapters.SQL.query(Changelog.Repo, "NOTIFY cache_ops, 'set:#{item}'", [])
   end
 
   def get(key) do
     result = :ets.lookup(@table_name, key)
+
     case result do
       [] -> nil
       [{_key, value}] -> value
     end
   end
 
-  def clear(key) do
+  defp set(key, data) do
+    :ets.insert(@table_name, {key, data})
+  end
+
+  defp clear(key) do
     :ets.delete(@table_name, key)
   end
 
   @impl true
-  def handle_info({:notification, _notification_pid, _listen_ref, "cache_clears", key}, state) do
-    IO.inspect(key, label: "clearing")
+  def handle_info(
+        {:notification, _notification_pid, _listen_ref, "cache_ops", "clear:" <> key},
+        state
+      ) do
+    Logger.debug(
+      "Clearing cache key '#{key}' on node #{inspect(Node.self())}, process #{inspect(self())}"
+    )
+
     clear(key)
     {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(
+        {:notification, _notification_pid, _listen_ref, "cache_ops", "set:" <> item},
+        state
+      ) do
+    {key, module, function, arguments} = postgres_string_to_term!(item)
+
+    Logger.debug(
+      "Setting cache key '#{key}' on node #{inspect(Node.self())}, process #{inspect(self)}"
+    )
+
+    data = apply(module, function, arguments)
+    set(key, data)
+    {:noreply, state}
+  end
+
+  defp term_to_postgres_string!(term) do
+    term
+    # Transform erlang data into a serialized form that can be transmitted
+    |> :erlang.term_to_binary()
+    # Postgres only wants simple string literals so we transform our binary
+    |> Base.encode64()
+    |> tap(fn string ->
+      # Just make it blow up if you for some reason send a hilariously big key
+      # or MFA that violates what we'd expect Postgres to handle
+      true = byte_size(string) < @postgres_notify_payload_limit
+    end)
+  end
+
+  defp postgres_string_to_term!(string) do
+    string
+    |> Base.decode64!()
+    |> :erlang.binary_to_term([:safe])
   end
 end

--- a/lib/changelog/application.ex
+++ b/lib/changelog/application.ex
@@ -6,10 +6,13 @@ defmodule Changelog.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    pg_config = Application.get_env(:changelog, Changelog.Repo) |> Keyword.put(:name, Changelog.PostgresNotifications)
     children = [
       ChangelogWeb.Endpoint,
       {Phoenix.PubSub, [name: Changelog.PubSub, adapter: Phoenix.PubSub.PG2]},
       Changelog.Repo,
+      {Postgrex.Notifications, pg_config},
+      Changelog.Cache2,
       # UA.Parser doesn't yet support new Supervisor child specification
       worker(UA.Parser, []),
       con_cache_child_spec(


### PR DESCRIPTION
Not done but this is the rough idea.

Run a GenServer that opens an ETS table. Offers a get/1, set/2, clear/1 and clear_all/1. Clearing all is the interesting case where this will tell all running app servers, through Postgres, to clear that key.

There are some notes on the possibility of using Phoenix.PubSub if you end up clustered. You could add that code now and it wouldn't really do any harm.

The postgres method would also work in the clustered version so either way works.