### PR TITLE
Migrate from AWS S3 to Cloudflare R2

### DIFF
--- a/.github/workflows/dagger_on_k8s.yml
+++ b/.github/workflows/dagger_on_k8s.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: "1.20"
           cache-dependency-path: "magefiles/go.sum"
 
-      - name: "Build, test, publish & deploy..."
+      - name: "Build, test & publish..."
         env:
           IMAGE_OWNER: "${{ vars.IMAGE_OWNER }}"
           GHCR_USERNAME: "${{ github.actor }}"
@@ -29,4 +29,5 @@ jobs:
           go run main.go -w ../ ci
 
       # TODO: run this in Dagger
+      # https://github.com/rtCamp/action-slack-notify/blob/v2.2.0/main.go
       # - name: "Announce deploy in #dev Slack..."

--- a/.github/workflows/ship_it.yml
+++ b/.github/workflows/ship_it.yml
@@ -8,9 +8,7 @@ concurrency:
 on:
   push:
     branches:
-      - '**'
-    tags-ignore:
-      - '**'
+      - 'master'
   pull_request:
   workflow_dispatch:
 

--- a/2022.fly/fly.toml
+++ b/2022.fly/fly.toml
@@ -10,9 +10,9 @@ strategy = "bluegreen"
 release_command = "mix ecto.migrate"
 
 [env]
-AWS_ASSETS_BUCKET = "changelog-assets"
 AWS_REGION = "us-east-1"
-AWS_UPLOADS_HOST = "https://changelog-assets.s3.amazonaws.com"
+AWS_ASSETS_BUCKET = "changelog-assets"
+R2_ASSETS_BUCKET = "changelog-assets"
 PORT = "4000"
 STATIC_URL_HOST = "cdn.changelog.com"
 URL_HOST = "changelog.com"

--- a/config/config.exs
+++ b/config/config.exs
@@ -68,16 +68,18 @@ config :shopify,
   password: SecretOrEnv.get("SHOPIFY_API_PASSWORD")
 
 config :ex_aws,
-  access_key_id: SecretOrEnv.get("AWS_ACCESS_KEY_ID"),
-  secret_access_key: SecretOrEnv.get("AWS_SECRET_ACCESS_KEY"),
-  region: SecretOrEnv.get("AWS_REGION")
+  access_key_id: SecretOrEnv.get("R2_ACCESS_KEY_ID"),
+  secret_access_key: SecretOrEnv.get("R2_SECRET_ACCESS_KEY")
+
+config :ex_aws, :s3,
+  host: SecretOrEnv.get("R2_API_HOST")
 
 config :ex_aws, :hackney_opts, recv_timeout: 300_000
 
 config :waffle,
   storage: Waffle.Storage.S3,
   version_timeout: 30_000,
-  bucket: SecretOrEnv.get("AWS_ASSETS_BUCKET")
+  bucket: SecretOrEnv.get("R2_ASSETS_BUCKET")
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,9 +58,9 @@ config :phoenix, :stacktrace_depth, 20
 
 config :phoenix, :plug_init_mode, :runtime
 
-# in dev route direct to R2
+# Serve Waffle static assets from Cloudflare R2 changelog-assets-dev, the r2.dev subdomain
 config :waffle,
-asset_host: "https://acd4d0fe190cbd98417069601607c33a.r2.cloudflarestorage.com/changelog-assets-dev"
+  asset_host: System.get_env("CDN_PUBLIC_HOST", "https://pub-09bcfd436e22494a8f79ac4e8cd51197.r2.dev")
 
 config :changelog, Changelog.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,8 +58,8 @@ config :phoenix, :stacktrace_depth, 20
 
 config :phoenix, :plug_init_mode, :runtime
 
-# in dev route direct to S3, in prod route through CDN
-config :waffle, asset_host: SecretOrEnv.get("AWS_UPLOADS_HOST")
+# in dev route direct to R2, in prod route through CDN
+config :waffle, asset_host: "https://" <> SecretOrEnv.get("R2_PUBLIC_HOST")
 
 config :changelog, Changelog.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -60,7 +60,7 @@ config :phoenix, :plug_init_mode, :runtime
 
 # in dev route direct to R2
 config :waffle,
-  asset_host: "https://acd4d0fe190cbd98417069601607c33a.r2.cloudflarestorage.com/changelog-assets"
+asset_host: "https://acd4d0fe190cbd98417069601607c33a.r2.cloudflarestorage.com/changelog-assets-dev"
 
 config :changelog, Changelog.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,8 +58,9 @@ config :phoenix, :stacktrace_depth, 20
 
 config :phoenix, :plug_init_mode, :runtime
 
-# in dev route direct to R2, in prod route through CDN
-config :waffle, asset_host: "https://" <> SecretOrEnv.get("R2_PUBLIC_HOST")
+# in dev route direct to R2
+config :waffle,
+  asset_host: "https://acd4d0fe190cbd98417069601607c33a.r2.cloudflarestorage.com/changelog-assets"
 
 config :changelog, Changelog.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -19,8 +19,9 @@ config :changelog, ChangelogWeb.Endpoint,
   # we don't need vsn=?d because Plug.Static doesn't serve static assets in prod
   cache_manifest_skip_vsn: true
 
-# in prod we point waffle to the CDN, just like we tell our own endpoint
-config :waffle, asset_host: "https://#{static_url_host}"
+# Serve Waffle static assets from our CDN, usually cdn.changelog.com
+config :waffle,
+  asset_host: "https://#{static_url_host}"
 
 if System.get_env("HTTPS") do
   config :changelog, ChangelogWeb.Endpoint,
@@ -58,7 +59,8 @@ config :changelog, Changelog.Mailer,
   username: SecretOrEnv.get("CM_SMTP_TOKEN"),
   password: SecretOrEnv.get("CM_SMTP_TOKEN")
 
-config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
+config :elixir,
+  :time_zone_database, Tzdata.TimeZoneDatabase
 
 config :changelog, Oban,
   plugins: [

--- a/lib/changelog/s3_static.ex
+++ b/lib/changelog/s3_static.ex
@@ -8,7 +8,7 @@ defmodule Changelog.S3Static do
   @app_path "priv/static"
 
   def upload_static_files_to_s3 do
-    s3_bucket = SecretOrEnv.get("AWS_ASSETS_BUCKET")
+    s3_bucket = SecretOrEnv.get("R2_ASSETS_BUCKET")
     static_path = Path.join(Application.app_dir(:changelog), @app_path)
 
     static_path
@@ -18,7 +18,7 @@ defmodule Changelog.S3Static do
   end
 
   def delete_unused_files_from_s3 do
-    s3_bucket = SecretOrEnv.get("AWS_ASSETS_BUCKET")
+    s3_bucket = SecretOrEnv.get("R2_ASSETS_BUCKET")
     static_path = Path.join(Application.app_dir(:changelog), @app_path)
 
     latest_files =

--- a/lib/changelog/stats/s3.ex
+++ b/lib/changelog/stats/s3.ex
@@ -1,9 +1,15 @@
 defmodule Changelog.Stats.S3 do
+  @config [
+      access_key_id: SecretOrEnv.get("AWS_ACCESS_KEY_ID"),
+      secret_access_key: SecretOrEnv.get("AWS_SECRET_ACCESS_KEY"),
+      host: SecretOrEnv.get("AWS_API_HOST")
+    ]
+
   def get_logs(date, slug) do
     bucket = "changelog-logs-#{slug}"
 
     ExAws.S3.list_objects(bucket, prefix: date)
-    |> ExAws.request!()
+    |> ExAws.request!(@config)
     |> get_in([:body, :contents])
     |> Task.async_stream(fn %{key: key} -> get_log(bucket, key) end)
     |> Enum.map(fn {:ok, log} -> log end)
@@ -11,7 +17,7 @@ defmodule Changelog.Stats.S3 do
 
   defp get_log(bucket, key) do
     ExAws.S3.get_object(bucket, key)
-    |> ExAws.request!()
+    |> ExAws.request!(@config)
     |> Map.get(:body)
   end
 end

--- a/magefiles/image/production.go
+++ b/magefiles/image/production.go
@@ -61,7 +61,7 @@ func (image *Image) ProductionClean() *Image {
 		WithImagemagick().
 		WithProdEnv()
 
-	if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
+	if os.Getenv("R2_ACCESS_KEY_ID") != "" {
 		image = image.UploadStaticAssets()
 	}
 
@@ -121,8 +121,9 @@ func (image *Image) ProductionImageRef() string {
 // 1. Upload legacy assets
 // 2. /wp-content/** redirect
 func (image *Image) UploadStaticAssets() *Image {
-	AWS_ACCESS_KEY_ID := env.Get(image.ctx, image.dag.Host(), "AWS_ACCESS_KEY_ID").Secret()
-	AWS_SECRET_ACCESS_KEY := env.Get(image.ctx, image.dag.Host(), "AWS_SECRET_ACCESS_KEY").Secret()
+	R2_API_HOST := env.Get(image.ctx, image.dag.Host(), "R2_API_HOST").Secret()
+	R2_ACCESS_KEY_ID := env.Get(image.ctx, image.dag.Host(), "R2_ACCESS_KEY_ID").Secret()
+	R2_SECRET_ACCESS_KEY := env.Get(image.ctx, image.dag.Host(), "R2_SECRET_ACCESS_KEY").Secret()
 
 	_, err := image.Production().
 		// 🤔 Why do we need to start the app - and therefore require the DB - to upload static assets?
@@ -135,11 +136,10 @@ func (image *Image) UploadStaticAssets() *Image {
 		WithExec([]string{
 			"mix", "ecto.migrate",
 		}).
-		WithEnvVariable("AWS_ASSETS_BUCKET", "changelog-assets").
-		WithEnvVariable("AWS_REGION", "us-east-1").
-		WithEnvVariable("AWS_UPLOADS_HOST", "https://changelog-assets.s3.amazonaws.com").
-		WithSecretVariable("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID).
-		WithSecretVariable("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY).
+		WithSecretVariable("R2_API_HOST", R2_API_HOST).
+		WithEnvVariable("R2_ASSETS_BUCKET", "changelog-assets").
+		WithSecretVariable("R2_ACCESS_KEY_ID", R2_ACCESS_KEY_ID).
+		WithSecretVariable("R2_SECRET_ACCESS_KEY", R2_SECRET_ACCESS_KEY).
 		WithExec([]string{
 			"mix", "changelog.static.upload",
 		}).


### PR DESCRIPTION
I believe all of the code changes needed to accomplish this migration are done. A few notes:

1.  All files uploaded and static assets served now use R2
2. The stats analyzer still uses S3 because Fastly's logging is failing to R2
3. Because of this, we have to keep `AWS_*` vars/secrets and we've added `R2_*` equivalents.

This still requires a migration phase. I believe this will look like:

1.  - [x] Configure new R2 secrets in Fly
2.  - [x] Migrate data from S3 bucket to R2 bucket
3.  - [ ] Merge/deploy this PR
4.  - [ ] Change Fastly's cdn.changelog.com host to use R2 origin (changelog.place)
5.  - [ ] Make sure we can upload new files and have them served correctly
6.  - [ ] Monitor Honeycomb for Fastly reporting origin weirdness/changes

Steps 2-5 should happen in timely succession. Is this the right order of things? **Anything I'm overlooking?**