### PR TITLE
Add status.changelog.com

### DIFF
--- a/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE.md
@@ -1,4 +1,4 @@
-[![shields.io](https://img.shields.io/badge/Last%20updated%20on-Mar.%2016%2C%202023-success?style=for-the-badge)](https://shipit.show/80)
+[![shields.io](https://img.shields.io/badge/Last%20updated%20on-Jul.%201%2C%202023-success?style=for-the-badge)](https://shipit.show/80)
 
 This diagram shows the current changelog.com setup:
 
@@ -76,11 +76,11 @@ graph TD
     secrets(( fa:fa-key 1Password )):::link
     click secrets "https://changelog.1password.com/"
     secrets -.-> |secrets| app
-    secrets -.-> |secrets| cicd
+    secrets -..-> |secrets| cicd
 
     %% Search
     search(( fa:fa-magnifying-glass Typesense ))
-    app -.-> |search| search
+    app -...-> |search| search
 
     %% Exceptions
     exceptions(( fa:fa-car-crash Sentry )):::link
@@ -99,10 +99,11 @@ graph TD
 
     %% Observability
     observability(( fa:fa-bug Honeycomb )):::link
-    click observability "https://ui.honeycomb.io/changelog/boards"
+    click observability "https://ui.honeycomb.io/changelog/datasets/changelog_opentelemetry/home"
     apex -.-> |logs| observability
-    app -..-> |traces| observability
+    app -....-> |traces| observability
     
+    %% Object storage
     apex ==> |https| proxy
     subgraph AWS.S3
         subgraph us-east-1
@@ -112,11 +113,17 @@ graph TD
     cdn ==> |https| assets
 
     %% Monitoring
-    monitoring(( fa:fa-table-tennis Pingdom )):::link
-    click monitoring "https://my.pingdom.com/app/newchecks/checks"
-    monitoring -...-> |monitors| apex
-    monitoring -.-> |monitors| cdn
-    monitoring -.-> |monitors| app
+    subgraph BetterStack
+        status[ fa:fa-layer-group status.changelog.com ]:::link
+        click status "https://status.changelog.com"
+
+        monitoring(( fa:fa-table-tennis Uptime )):::link
+        click monitoring "https://uptime.betterstack.com/team/133302/monitors"
+        monitoring -....-> |monitors| apex
+        monitoring -.-> |monitors| cdn
+        monitoring -.-> |monitors| proxy
+        monitoring -.-> |monitors| status
+    end
 ```
 
 > **Note**
@@ -218,7 +225,7 @@ We also send app traces via OpenTelemetry to Honeycomb.io.
 
 App errors - e.g. `Plug.Conn.InvalidQueryError` - show up in Sentry.io.
 
-Pingdom.com monitors our public HTTPS endpoints & alerts us when they become unhealthy.
+BetterStack.com monitors our public HTTPS endpoints & alerts us when they become unhealthy.
 
 
 ## Search

--- a/lib/changelog_web/templates/layout/_footer.html.eex
+++ b/lib/changelog_web/templates/layout/_footer.html.eex
@@ -85,9 +85,11 @@
         <li><%= link("Search", to: Routes.search_path(@conn, :search), title: "Search Changelog") %></li>
         <li><a href="https://github.com/thechangelog/changelog.com" title="Changelog.com source code">View Source</a></li>
         <li>---</li>
-        <li><a href="https://github.com/thechangelog/changelog.com/issues" title="Changelog.com issue tracker">Report Issues</a></li>
+        <li><a href="https://github.com/thechangelog/changelog.com/issues/new" title="Report a Changelog.com issue">Report an Issue</a></li>
         <li><a href="/terms" title="Terms & Conditions">Terms &amp; Conditions</a></li>
         <li><a href="/privacy" title="Privacy Policy">Privacy Policy</a></li>
+        <li>---</li>
+        <li><a href="https://status.changelog.com" title="Changelog.com services status">Status</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
You may remember us mentioning in https://changelog.com/friends/2#transcript-369 that we switched off Pingdom. As it turns out, we still want external, synthetic monitoring that offers a public status page that we can use to communicate incidents with the outside world. BetterStack.com seems to fit nicely. Check it out: https://status.changelog.com

<img width="1056" alt="image" src="https://github.com/thechangelog/changelog.com/assets/3342/aa1f11e8-7542-4b5b-a9a7-e53bae137f3d">

We are currently on the Basic (free) tier. This limits us to a 3-minute check interval & 10 monitors, which is good-enough for now. Leaving this one with @adamstac 💪

---

✅ link in the footer

![image](https://github.com/thechangelog/changelog.com/assets/3342/1f49f4f4-846f-4187-b07e-ca1cd3ce450f)

---

✅ update infrastructure diagram

<img width="1537" alt="image" src="https://github.com/thechangelog/changelog.com/assets/3342/5b66ca22-80b2-4393-9e25-64c5e2e5ecd3">