### PR TITLE
Limit app traces sent to Honeycomb.io

### DIFF
--- a/2022.fly/fly.toml
+++ b/2022.fly/fly.toml
@@ -17,6 +17,9 @@ PORT = "4000"
 STATIC_URL_HOST = "cdn.changelog.com"
 URL_HOST = "changelog.com"
 DB_NAME = "changelog"
+# Sample traces to 10%, otherwise we will exceed out monthly 100M limit
+OTEL_TRACES_SAMPLER="parentbased_traceidratio"
+OTEL_TRACES_SAMPLER_ARG="0.1"
 
 [[services]]
 internal_port = 4000

--- a/config/config.exs
+++ b/config/config.exs
@@ -118,6 +118,7 @@ if System.get_env("HONEYCOMB_API_KEY") do
   config :opentelemetry, traces_exporter: :otlp
   config :opentelemetry_exporter,
     otlp_protocol: :http_protobuf,
+    otlp_compression: :gzip,
     otlp_endpoint: "https://api.honeycomb.io:443",
     otlp_headers: [
       {"x-honeycomb-team", SecretOrEnv.get("HONEYCOMB_API_KEY")},


### PR DESCRIPTION
The problem that this solves:
<img width="806" alt="image" src="https://github.com/thechangelog/changelog.com/assets/3342/fa32f6bf-367d-453a-a117-d7eb25087586">

Before & after this change (booting the app locally):
<img width="1190" alt="image" src="https://github.com/thechangelog/changelog.com/assets/3342/57d53b26-cde3-45b7-b54e-0efbe29dfa70">

---

FWIW: https://github.com/open-telemetry/opentelemetry-erlang/blob/4812195bfa52031dfceeddf6290d0a4cfbc5470c/apps/opentelemetry/src/otel_configuration.erl#L219-L237