### PR TITLE
Bump deps to latest

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   devcontainer:
-    image: ghcr.io/thechangelog/changelog-runtime:elixir-v1.14.4-erlang-v25.3.2-nodejs-v18.16.0
+    image: ghcr.io/thechangelog/changelog-runtime:elixir-v1.14.5-erlang-v26.2-nodejs-v20.10.0
     volumes:
       - ../:/workspace
     network_mode: service:db

--- a/.tool-versions
+++ b/.tool-versions
@@ -6,4 +6,3 @@ nodejs 20.10.0
 yarn 1.22.19
 postgres 15.3
 flyctl 0.1.134
-mage 1.15.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,9 +1,9 @@
 direnv 2.32.3
-elixir 1.14.4
-erlang 25.3.2
-golang 1.20.4
-nodejs 18.17.0
+elixir 1.14.5
+erlang 26.2
+golang 1.20.12
+nodejs 20.10.0
 yarn 1.22.19
 postgres 15.3
-flyctl 0.1.66
+flyctl 0.1.134
 mage 1.15.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,8 @@ Create a new pull request via https://github.com/thechangelog/changelog.com
 You will need to have the following dependencies installed:
 - [PostgreSQL](https://www.postgresql.org/download/) v15
 - [Elixir](https://elixir-lang.org/install.html) v1.14
-- [Erlang/OTP](https://www.erlang.org/downloads) v25 - usually installed as an Elixir dependency
-- [Node.js](https://nodejs.org/en/download/) v18 LTS - [latest-v18.x](https://nodejs.org/download/release/latest-v18.x/)
+- [Erlang/OTP](https://www.erlang.org/downloads) v26 - usually installed as an Elixir dependency
+- [Node.js](https://nodejs.org/en/download/) v20 LTS - [latest-v20.x](https://nodejs.org/download/release/latest-v20.x/)
 - [Yarn](https://yarnpkg.com/getting-started/install) v1.22
 - [Golang](https://go.dev/doc/install) v1.20 - if you want to run CI locally
 
@@ -96,14 +96,14 @@ This is what that looks like on macOS 12, our usual development environment:
 # 🛠 INSTALL DEPENDENCIES 🛠
 asdf install
 
-#👇 installed on a MacBook Pro 16" (2021) running macOS 12.6.3 in ~4mins on May 20, 2023 by @gerhard
-# - Elixir v1.14.4
-# - Erlang v25.3.2
-# - Golang 1.20.4
-# - Node.js v18.16.0
+#👇 installed on a MacBook Pro 16" (2021) running macOS 12.7.1 in ~4mins on Dec 16, 2023 by @gerhard
+# - Elixir v1.14.5
+# - Erlang v26.2
+# - Golang 1.20.12
+# - Node.js v20.10.0
 # - Yarn v1.22.19
 # - PostgreSQL v14.1
-#👆 installed on a MacBook Pro 16" (2021) running macOS 12.6.3 in ~4mins on May 20, 2023 by @gerhard
+#👆 installed on a MacBook Pro 16" (2021) running macOS 12.7.1 in ~4mins on Dec 16, 2023 by @gerhard
 
 # You will also need to install imagemagick via Homebrew.
 # asdf imagemagick plugin did not work for me.
@@ -139,7 +139,7 @@ mix test
 
 ## How to upgrade 💜 Elixir, 🚜 Erlang/OTP & ⬢ Node.js?
 
-1. Run e.g. `asdf install erlang latest:25`
+1. Run e.g. `asdf install erlang latest:26`
     - If a new version gets installed, run `asdf local erlang <INSTALLED_VERSION>`
 2. Repeat previous step for Elixir & Node.js
 3. Commit & push to check that image builds successfully in GitHub Actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ This is what that looks like on macOS 12, our usual development environment:
 
 ```console
 # 🛠 INSTALL DEPENDENCIES 🛠
+awk '{ system("asdf plugin-add " $1) }' < .tool-versions
 asdf install
 
 #👇 installed on a MacBook Pro 16" (2021) running macOS 12.7.1 in ~4mins on Dec 16, 2023 by @gerhard
@@ -102,7 +103,7 @@ asdf install
 # - Golang 1.20.12
 # - Node.js v20.10.0
 # - Yarn v1.22.19
-# - PostgreSQL v14.1
+# - PostgreSQL v15.3
 #👆 installed on a MacBook Pro 16" (2021) running macOS 12.7.1 in ~4mins on Dec 16, 2023 by @gerhard
 
 # You will also need to install imagemagick via Homebrew.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ mix test
     - If a new version gets installed, run `asdf local erlang <INSTALLED_VERSION>`
 2. Repeat previous step for Elixir & Node.js
 3. Commit & push to check that image builds successfully in GitHub Actions
-    - _Alternatively_, build the image locally via: `mage image:runtime`
+    - _Alternatively_, build the image locally via: `{ cd magefiles && go run main.go -w ../ image:runtime }`
 
 After you confirm that the image builds successfully:
 1. Update `.devcontainer/docker-compose.yml` with new image tag

--- a/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE.md
@@ -154,7 +154,7 @@ TL;DR:
 [Node.js](https://nodejs.org) to digest & compile static assets (CSS & JS).
 
 Static assets, including all our mp3 episodes, are stored on Cloudflare R2.
-They are served via Fastly, specifically https://cdn.changelog.com. In summary:
+They are served via Fastly, specifically https://cdn.changelog.com.
 
 ```
 Fastly (cdn.changelog.com)
@@ -164,7 +164,7 @@ Cloudflare R2 (changelog.place)
 
 The production instance of our application is running on Fly.io. All
 https://changelog.com requests are served via Fastly. Each Fastly request gets
-proxied to our application instance via the Fly.io Proxy. In summary:
+proxied to our application instance via the Fly.io Proxy.
 
 ```
 Fastly (changelog.com)
@@ -175,7 +175,7 @@ Application (changelog-2022-03-13.fly.dev)
 ```
 
 The production database - PostgreSQL - is running on Fly.io too. It is a
-replicated setup, with one leader & one replica. In summary:
+replicated setup, with one leader & one replica.
 
 ```
 Application (changelog-2022-03-13.fly.dev)

--- a/magefiles/image/runtime.go
+++ b/magefiles/image/runtime.go
@@ -205,9 +205,6 @@ func (image *Image) WithNodejs() *Image {
 		}).
 		WithExec([]string{
 			"npm", "--version",
-		}).
-		WithExec([]string{
-			"rm", fmt.Sprintf("/opt/%s.tar.xz", NodejsVersionAndPlatform),
 		})
 
 	return image

--- a/magefiles/image/runtime.go
+++ b/magefiles/image/runtime.go
@@ -197,7 +197,7 @@ func (image *Image) WithNodejs() *Image {
 			fmt.Sprintf("https://nodejs.org/dist/v%s/%s.tar.xz", image.versions.Nodejs(), NodejsVersionAndPlatform),
 		}).
 		WithExec([]string{
-			"tar", "-xJvf", fmt.Sprintf("/opt/%s.tar.xz", NodejsVersionAndPlatform), "-C", "/opt",
+			"tar", "-xJf", fmt.Sprintf("/opt/%s.tar.xz", NodejsVersionAndPlatform), "-C", "/opt",
 		}).
 		WithEnvVariable("PATH", fmt.Sprintf("/opt/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", NodejsVersionAndPlatform)).
 		WithExec([]string{

--- a/magefiles/tools/main.go
+++ b/magefiles/tools/main.go
@@ -24,7 +24,7 @@ func CurrentVersions() *Versions {
 		toolVersions: toolVersions(),
 		Ubuntu: Ubuntu{
 			// https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy
-			Short: "jammy-20230126",
+			Short: "jammy-20231004",
 			Long:  "22.04 LTS (Jammy Jellyfish)",
 		},
 	}


### PR DESCRIPTION
This started as a flyctl upgrade (the version that we were using was unsupported), and then moved to other dependencies.

It's been a while (>4 months), time to pull the latest minors and see if anything breaks:
- Ubuntu 22.04 LTS (Jammy Jellyfish) `2023-10-04`
- Elixir 1.14.5
- Golang 1.20.12
- flyctl 0.1.134

For Node.js, pull the latest Active LTS, which is currently:
- Node.js 20.10.0 FTR: https://nodejs.org/en/about/previous-releases

For Erlang, a few minors for 26 already appeared, and everything seems to be working as expected, so let's bump to latest stable:
- Erlang 26.2

We should also bump Elixir to latest minor (currently 1.15) as a follow-up. There were issues with it, will add more details to the PR.