### PR TITLE
Upgrade Elixir to v1.15

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 direnv 2.32.3
-elixir 1.14.5
+elixir 1.15.7
 erlang 26.2
 golang 1.20.12
 nodejs 20.10.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Create a new pull request via https://github.com/thechangelog/changelog.com
 
 You will need to have the following dependencies installed:
 - [PostgreSQL](https://www.postgresql.org/download/) v15
-- [Elixir](https://elixir-lang.org/install.html) v1.14
+- [Elixir](https://elixir-lang.org/install.html) v1.15
 - [Erlang/OTP](https://www.erlang.org/downloads) v26 - usually installed as an Elixir dependency
 - [Node.js](https://nodejs.org/en/download/) v20 LTS - [latest-v20.x](https://nodejs.org/download/release/latest-v20.x/)
 - [Yarn](https://yarnpkg.com/getting-started/install) v1.22
@@ -98,7 +98,7 @@ awk '{ system("asdf plugin-add " $1) }' < .tool-versions
 asdf install
 
 #👇 installed on a MacBook Pro 16" (2021) running macOS 12.7.1 in ~4mins on Dec 16, 2023 by @gerhard
-# - Elixir v1.14.5
+# - Elixir v1.15.7
 # - Erlang v26.2
 # - Golang 1.20.12
 # - Node.js v20.10.0

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Changelog.Mixfile do
     [
       app: :changelog,
       version: System.get_env("APP_VERSION", "0.0.1"),
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
Currently `mix deps.compile` fails with:

```console
│ ┃ Compiling 7 files (.erl)
│ ┃ src/ssl_verify_fingerprint.erl:15:14: can't find include lib "public_key/include/public_key.hrl"
│ ┃ %   15| -include_lib("public_key/include/public_key.hrl").
│ ┃ %     |              ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:13:14: can't find include lib "public_key/include/public_key.hrl"
│ ┃ %   13| -include_lib("public_key/include/public_key.hrl").
│ ┃ %     |              ^
│ ┃
│ ┃ src/ssl_verify_pk.erl:14:14: can't find include lib "public_key/include/public_key.hrl"
│ ┃ %   14| -include_lib("public_key/include/public_key.hrl").
│ ┃ %     |              ^
│ ┃
│ ┃ src/ssl_verify_hostname.erl:16:14: can't find include lib "public_key/include/public_key.hrl"
│ ┃ %   16| -include_lib("public_key/include/public_key.hrl").
│ ┃ %     |              ^
│ ┃
│ ┃ src/ssl_verify_fingerprint.erl:27:26: record 'OTPCertificate' undefined
│ ┃ %   27| -spec verify_fun(Cert :: #'OTPCertificate'{},
│ ┃ %     |                          ^
│ ┃
│ ┃ src/ssl_verify_pk.erl:26:26: record 'OTPCertificate' undefined
│ ┃ %   26| -spec verify_fun(Cert :: #'OTPCertificate'{},
│ ┃ %     |                          ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:23:34: undefined macro 'id-ce-subjectAltName'
│ ┃ %   23|   AltSubject = select_extension(?'id-ce-subjectAltName', Extensions),
│ ┃ %     |                                  ^
│ ┃
│ ┃ src/ssl_verify_hostname.erl:28:26: record 'OTPCertificate' undefined
│ ┃ %   28| -spec verify_fun(Cert :: #'OTPCertificate'{},
│ ┃ %     |                          ^
│ ┃
│ ┃ src/ssl_verify_fingerprint.erl:29:39: record 'Extension' undefined
│ ┃ %   29|                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
│ ┃ %     |                                       ^
│ ┃
│ ┃ src/ssl_verify_pk.erl:28:39: record 'Extension' undefined
│ ┃ %   28|                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
│ ┃ %     |                                       ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:9:2: function extract_dns_names/1 undefined
│ ┃ %    9| -export([extract_dns_names/1,
│ ┃ %     |  ^
│ ┃
│ ┃ src/ssl_verify_hostname.erl:30:39: record 'Extension' undefined
│ ┃ %   30|                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
│ ┃ %     |                                       ^
│ ┃
│ ┃ src/ssl_verify_pk.erl:51:30: record 'OTPCertificate' undefined
│ ┃ %   51| -spec verify_cert_pk(Cert :: #'OTPCertificate'{}, Pk :: pk()) ->
│ ┃ %     |                              ^
│ ┃
│ ┃ src/ssl_verify_fingerprint.erl:52:39: record 'OTPCertificate' undefined
│ ┃ %   52| -spec verify_cert_fingerprint(Cert :: #'OTPCertificate'{}, Fingerprint :: fingerprint()) ->
│ ┃ %     |                                       ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:19:2: spec for undefined function extract_dns_names/1
│ ┃ %   19| -spec extract_dns_names(Cert :: #'OTPCertificate'{}) -> [] | [string()].
│ ┃ %     |  ^
│ ┃
│ ┃ src/ssl_verify_hostname.erl:46:36: record 'OTPCertificate' undefined
│ ┃ %   46| -spec verify_cert_hostname(Cert :: #'OTPCertificate'{}, Hostname :: hostname()) ->
│ ┃ %     |                                    ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:19:33: record 'OTPCertificate' undefined
│ ┃ %   19| -spec extract_dns_names(Cert :: #'OTPCertificate'{}) -> [] | [string()].
│ ┃ %     |                                 ^
│ ┃
│ ┃ src/ssl_verify_hostname.erl:76:38: record 'OTPCertificate' undefined
│ ┃ %   76|                              Cert :: #'OTPCertificate'{},
│ ┃ %     |                                      ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:32:26: record 'OTPCertificate' undefined
│ ┃ %   32| -spec extract_cn(Cert :: #'OTPCertificate'{}) -> {error, no_common_name} | {ok, string()} | {error, invalid}.
│ ┃ %     |                          ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:34:17: record 'OTPCertificate' undefined
│ ┃ %   34|   TBSCert = Cert#'OTPCertificate'.tbsCertificate,
│ ┃ %     |                 ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:35:32: record 'OTPTBSCertificate' undefined
│ ┃ %   35|   {rdnSequence, List} = TBSCert#'OTPTBSCertificate'.subject,
│ ┃ %     |                                ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:38:26: record 'OTPCertificate' undefined
│ ┃ %   38| -spec extract_pk(Cert :: #'OTPCertificate'{}) -> {error, no_common_name} | #'SubjectPublicKeyInfo'{}.
│ ┃ %     |                          ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:38:76: record 'SubjectPublicKeyInfo' undefined
│ ┃ %   38| -spec extract_pk(Cert :: #'OTPCertificate'{}) -> {error, no_common_name} | #'SubjectPublicKeyInfo'{}.
│ ┃ %     |                                                                            ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:40:17: record 'OTPCertificate' undefined
│ ┃ %   40|   TBSCert = Cert#'OTPCertificate'.tbsCertificate,
│ ┃ %     |                 ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:41:26: record 'OTPTBSCertificate' undefined
│ ┃ %   41|   PublicKeyInfo = TBSCert#'OTPTBSCertificate'.subjectPublicKeyInfo,
│ ┃ %     |                          ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:42:16: record 'OTPSubjectPublicKeyInfo' undefined
│ ┃ %   42|   PublicKeyInfo#'OTPSubjectPublicKeyInfo'.subjectPublicKey.
│ ┃ %     |                ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:48:24: record 'Extension' undefined
│ ┃ %   48| -spec extensions_list([#'Extension'{}] | asn1_NOVALUE) -> [] | [#'Extension'{}].
│ ┃ %     |                        ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:48:65: record 'Extension' undefined
│ ┃ %   48| -spec extensions_list([#'Extension'{}] | asn1_NOVALUE) -> [] | [#'Extension'{}].
│ ┃ %     |                                                                 ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:55:39: record 'Extension' undefined
│ ┃ %   55| -spec select_extension(Id :: term(), [#'Extension'{}]) -> undefined | #'Extension'{}.
│ ┃ %     |                                       ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:55:71: record 'Extension' undefined
│ ┃ %   55| -spec select_extension(Id :: term(), [#'Extension'{}]) -> undefined | #'Extension'{}.
│ ┃ %     |                                                                       ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:57:28: record 'Extension' undefined
│ ┃ %   57|   Matching = [Extension || #'Extension'{extnID = ExtId} = Extension <- Extensions, ExtId =:= Id],
│ ┃ %     |                            ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:57:84: variable 'ExtId' is unbound
│ ┃ %   57|   Matching = [Extension || #'Extension'{extnID = ExtId} = Extension <- Extensions, ExtId =:= Id],
│ ┃ %     |                                                                                    ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:75:15: record 'AttributeTypeAndValue' undefined
│ ┃ %   75| extract_cn2([[#'AttributeTypeAndValue'{type={2, 5, 4, 3},
│ ┃ %     |               ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:77:39: variable 'CN' is unbound
│ ┃ %   77|   ssl_verify_fun_encodings:get_string(CN);
│ ┃ %     |                                       ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:49:1: Warning: function extensions_list/1 is unused
│ ┃ %   49| extensions_list(E) ->
│ ┃ %     | ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:56:1: Warning: function select_extension/2 is unused
│ ┃ %   56| select_extension(Id, Extensions) ->
│ ┃ %     | ^
│ ┃
│ ┃ src/ssl_verify_fun_cert_helpers.erl:64:1: Warning: function extract_dns_names_from_alt_names/2 is unused
│ ┃ %   64| extract_dns_names_from_alt_names([ExtValue | Rest], Acc) ->
│ ┃ %     | ^
│ ┃
│ ┃ could not compile dependency :ssl_verify_fun, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compil
│ ┃ e ssl_verify_fun --force", update it with "mix deps.update ssl_verify_fun" or clean it with "mix deps.clean ssl_verify_fun"
┻ ┻
• Engine: f26e50975d18
• Duration: 2m25.499s
exit status 73
```

---

Follow-up  to:
- https://github.com/thechangelog/changelog.com/pull/490