### PR TITLE
Only install dev & test deps when contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,8 @@ createdb changelog_test --username=postgres
 
 # 💜 CONFIGURE APP 💜
 # Install deps
-mix deps.get
+mix deps.get --only dev
+mix deps.get --only test
 # Prepare dev database
 mix ecto.setup
 


### PR DESCRIPTION
`mix deps.get` requires access to oban repository which is not available to contributors. This updates the contributing docs to reflect that.

Closes #494