### PR TITLE
Send all app traces to Honeycomb

### DIFF
--- a/2022.fly/fly.toml
+++ b/2022.fly/fly.toml
@@ -17,9 +17,6 @@ PORT = "4000"
 STATIC_URL_HOST = "cdn.changelog.com"
 URL_HOST = "changelog.com"
 DB_NAME = "changelog"
-# Sample traces to 10%, otherwise we will exceed out monthly 100M limit
-OTEL_TRACES_SAMPLER="parentbased_traceidratio"
-OTEL_TRACES_SAMPLER_ARG="0.1"
 
 [[services]]
 internal_port = 4000


### PR DESCRIPTION
Our monthly Honeycomb.io plan limit is now 450M (up from 100M).

We no longer need to sample app traces: let's send them all!

This reverts https://github.com/thechangelog/changelog.com/pull/482

---
<img width="796" alt="image" src="https://github.com/thechangelog/changelog.com/assets/3342/8f1e31af-4aad-40d1-8723-2d15ecd70975">
