### PR TITLE
Deploy PgHero & connect to Neon.tech Postgres

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,10 +1,10 @@
-direnv 2.32.3
+direnv 2.34.0
 elixir 1.14.5
-erlang 26.2
-golang 1.20.12
-nodejs 20.10.0
+erlang 26.2.3
+golang 1.22.1
+nodejs 20.11.1
 yarn 1.22.19
-postgres 16.1
-flyctl 0.1.135
-1password-cli 2.24.0
+postgres 16.2
+flyctl 0.2.25
+1password-cli 2.26.1
 dagger 0.6.4

--- a/fly.io/pghero-2024-03-27/README.md
+++ b/fly.io/pghero-2024-03-27/README.md
@@ -1,0 +1,35 @@
+# A Performance Dashboard for Postgres
+
+This sets up [PgHero](https://github.com/ankane/pghero) (a performance
+dashboard) for our Neon.tech Postgres instance.
+
+It runs on Fly.io and is only available on our private network (requires a
+running Wireguard Tunnel).
+
+## Deploy
+
+1. `flyctl apps create pghero-2024-03-27 --org changelog`
+2. `flyctl secrets set DATABASE_URL="$(op read op://changelog/neon/url --account changelog.1password.com --cache)"`
+3. `flyctl deploy --ha=false --vm-memory=512`
+
+## Connect
+
+> [!NOTE]
+> Skip if you already have a WireGuard Tunnel configured.
+
+Now connect to this PgHero instance running on Fly.io:
+
+1. Create a Wireguard peer: `flyctl wireguard create changelog lhr gerhard-2024-03-27`
+2. Save it to e.g. `~/Desktop/fly.io-changelog-lhr-gerhard-2024-03-27.conf`
+3. **Import Tunnel(s) from File...** it in WireGuard - [install](https://www.wireguard.com/install/) if needed
+4. Activate new Tunnel
+5. Connect to PgHero: <http://pghero-2024-03-27.internal:8080>
+
+## Delete
+
+`flyctl destroy pghero-2024-03-27`
+
+## Shout-out
+
+- @ankane for [PgHero](https://github.com/ankane/pghero) 🦸
+- @brendan-stephens for [the pairing session](https://github.com/thechangelog/changelog.com/pull/492#issuecomment-1885586669) 🍐

--- a/fly.io/pghero-2024-03-27/fly.toml
+++ b/fly.io/pghero-2024-03-27/fly.toml
@@ -1,0 +1,23 @@
+# https://fly.io/docs/reference/configuration/
+
+app = "pghero-2024-03-27"
+primary_region = "iad"
+
+[build]
+  # https://hub.docker.com/r/ankane/pghero/tags
+  image = "ankane/pghero:v3.4.1@sha256:bbf82670a228c3df4a3198a1aa2db4e0a66e110d08d7b12e4de49cabcf451052"
+
+[env]
+  BIND = 'tcp://[::]:8080'
+
+[[services]]
+internal_port = 8080
+protocol = "tcp"
+
+[[services.http_checks]]
+grace_period = "10s"
+interval = "15s"
+method = "get"
+path = "/health"
+protocol = "http"
+timeout = "10s"

--- a/magefiles/tools/main.go
+++ b/magefiles/tools/main.go
@@ -24,7 +24,7 @@ func CurrentVersions() *Versions {
 		toolVersions: toolVersions(),
 		Ubuntu: Ubuntu{
 			// https://hub.docker.com/r/hexpm/elixir/tags?page=1&ordering=last_updated&name=ubuntu-jammy
-			Short: "jammy-20231004",
+			Short: "jammy-20240125",
 			Long:  "22.04 LTS (Jammy Jellyfish)",
 		},
 	}


### PR DESCRIPTION
- Provides insights into our Neon.tech Postgres setup
- Available on our 6PN network as <http://pghero-2024-03-27.internal:8080>
<img width="976" alt="image" src="https://github.com/thechangelog/changelog.com/assets/3342/1f505bcd-a653-43a8-83b4-302b5d2bf60e">


While at it, I've also bumped all utilities to latest (except Elixir - #493)

---

Follow-up to:
- https://github.com/thechangelog/changelog.com/pull/492