### PR TITLE
Remove `#` from episode numbers in commit messages

### DIFF
--- a/lib/changelog/github/source.ex
+++ b/lib/changelog/github/source.ex
@@ -24,7 +24,7 @@ defmodule Changelog.Github.Source do
 
   defp joined(list), do: Enum.join(list, "/")
 
-  defp name(episode), do: "#{episode.podcast.name} ##{episode.slug}"
+  defp name(episode), do: "#{episode.podcast.name} #{episode.slug}"
 
   defp path(episode) do
     podcast_name = PodcastView.dasherized_name(episode.podcast)


### PR DESCRIPTION
## Description

@changelogbot keeps show notes, transcripts, and other content up to date. It creates commit titles like `Add Changelog & Friends #46`.

On changelog.com, referring to episodes like `Changelog & Friends #46` is no problem. GitHub, however, will [autolink](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) these episode references and think they are issue or PR numbers.

For example, here's a commit (https://github.com/thechangelog/show-notes/commit/076c2389f226ecf984223ef78ab46799f1277780) referencing a PR that has nothing to do with the show notes being committed:

<img src="https://github.com/thechangelog/changelog.com/assets/26674818/b53ac75e-7009-4e20-9088-b57d56673133" alt="Screenshot of thechangelog-show-notes showing that a commit title is autolinked to a PR" width="75%" />

## Changes

`lib/changelog/github/source.ex` appears to be where the leading `#` is added.

https://github.com/thechangelog/changelog.com/blob/6e829884b319d7e02f1280c079d800d108c334a5/lib/changelog/github/source.ex#L27

This PR will update `lib/changelog/github/source.ex` to remove the leading `#` and avoid having GitHub autolink the episode numbers.

WDYT?

Did I fix the right thing?

Will this break other stuff I don't know about?
