### PR TITLE
Trace GitHub Actions Workflows

### DIFF
--- a/.github/workflows/trace_workflows.yml
+++ b/.github/workflows/trace_workflows.yml
@@ -1,0 +1,28 @@
+name: "Trace GitHub Actions Workflows"
+
+on:
+  workflow_run:
+    workflows:
+      - "Dagger on K8s"
+      - "Dagger on GitHub"
+      - "Dagger on Fly.io"
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Export '${{ github.event_name }}' workflow trace
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'thechangelog/changelog.com' }}
+    steps:
+      - name: Export Workflow Trace
+        uses: corentinmusard/otel-cicd-action@9d13430746676ba690999657315ec3f162269f49
+        with:
+          otlpEndpoint: grpc://api.honeycomb.io:443/
+          otlpHeaders: ${{ secrets.HONEYCOMB_GITHUB_ACTIONS_WORKFLOWS }}
+          otelServiceName: github-actions
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
When workflows complete, send the entire workflow trace to Honeycomb so that we can track workflow behaviour over time, e.g.
- success rate
- duration

This will show us detailed view into every step of the workflow.

---
Now that the integration is complete, this is what we can see:

### [Workflows + pipelines by conclusion & duration](https://ui.honeycomb.io/changelog/board/jgqR2BAfaQM/GitHub-Actions)
<img width="1552" alt="Screenshot 2024-06-10 at 08 06 14" src="https://github.com/thechangelog/changelog.com/assets/3342/0e14b10d-c8f8-46b5-8590-041c789395e1">
<img width="1552" alt="Screenshot 2024-06-10 at 08 06 23" src="https://github.com/thechangelog/changelog.com/assets/3342/71792800-7a51-4b89-8a3c-81b175f6135e">

### [We can also dig into a specific workflow and see all its steps as traces](https://ui.honeycomb.io/changelog/datasets/github-actions/result/k1v8vYBYqbh/trace/stNdX14muSb?fields[]=s_name&fields[]=s_serviceName&source=query&span=4b6d85cd7ce016a8)
<img width="1552" alt="Screenshot 2024-06-10 at 08 06 44" src="https://github.com/thechangelog/changelog.com/assets/3342/7cc0fd16-7d2f-49cf-8055-d6de032e3ed1">
<img width="1552" alt="Screenshot 2024-06-10 at 08 06 52" src="https://github.com/thechangelog/changelog.com/assets/3342/1e561c37-2f08-4d60-88ae-ecc36bd0e83f">

The only thing left now is to push a few commits to `master` so that we can see a few of these workflow & pipeline runs, and see how they compare over a longer period of time. We have `5days` until we record the next Kaizen: https://github.com/thechangelog/changelog.com/discussions/511

Let's unleash `push to master` 🚀 cc @jerodsanto @adamstac 