### PR TITLE
Improve on the Zulip auth app integration

### DIFF
--- a/env.op
+++ b/env.op
@@ -54,3 +54,13 @@ export TYPESENSE_URL="op://changelog/typesense/url"
 
 export STRIPE_SECRET="op://changelog/stripe/api_secret"
 export STRIPE_WEBHOOK_SECRET="op://changelog/stripe/webhook_secret"
+
+export STRIPE_SECRET="op://changelog/stripe/api_secret"
+export STRIPE_WEBHOOK_SECRET="op://changelog/stripe/webhook_secret"
+
+export ZULIP_ADMIN_USER="op://changelog/zulip/admin_user"
+export ZULIP_ADMIN_API_KEY="op://changelog/zulip/admin_api_key"
+export ZULIP_USER="op://changelog/zulip/user"
+export ZULIP_API_KEY="op://changelog/zulip/user_api_key"
+export ZULIP_BOT_USER="op://changelog/zulip/bot_user"
+export ZULIP_BOT_API_KEY="op://changelog/zulip/bot_api_key"


### PR DESCRIPTION
We want to reference all secrets from 1Password so that when we need to rotate anything, we simply update the values in 1Password and restart the app so that it reads the new values just-in-time, at boot time.

FTR:
- https://github.com/thechangelog/changelog.com/pull/492#issuecomment-1872528092

---

**AFTER** this gets merged & deployed into production:
- [x] confirm that the new env vars work as expected
- [x] remove fly app secrets

```console
flyctl secrets unset ZULIP_ADMIN_USER ZULIP_ADMIN_API_KEY ZULIP_USER ZULIP_API_KEY ZULIP_BOT_USER ZULIP_BOT_API_KEY
```