### PR TITLE
Announce deploys in Zulip from GitHub runners too

### DIFF
--- a/.github/workflows/dagger_on_github.yml
+++ b/.github/workflows/dagger_on_github.yml
@@ -48,12 +48,17 @@ jobs:
           cd magefiles
           go run main.go -w ../ cd
 
-      - name: "Announce deploy in #dev Slack..."
+      - name: "Announce deploy in #kaizen Zulip..."
         if: ${{ github.repository == 'thechangelog/changelog.com' && github.ref_name == 'master' }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          MSG_MINIMAL: "commit,actions url"
-          SLACK_CHANNEL: dev
-          SLACK_USERNAME: "GitHub Actions"
-          SLACK_FOOTER: "Just got shipped to https://changelog.com"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_BOT_API_KEY }}
+          email: "logbot-bot@changelog.zulipchat.com"
+          organization-url: "https://changelog.zulipchat.com"
+          to: "kaizen"
+          type: "stream"
+          topic: "Code deploys"
+          content: |
+            ${{ github.actor }} just successfully deployed [${{ env.SHORT_SHA }}](https://github.com/thechangelog/changelog.com/commit/${{ github.sha }}):
+
+            > ${{ github.event.commits[0].message }}

--- a/.github/workflows/dagger_on_k8s.yml
+++ b/.github/workflows/dagger_on_k8s.yml
@@ -31,7 +31,3 @@ jobs:
         run: |
           cd magefiles
           go run main.go -w ../ ci
-
-      # TODO: run this in Dagger
-      # https://github.com/rtCamp/action-slack-notify/blob/v2.2.0/main.go
-      # - name: "Announce deploy in #dev Slack..."


### PR DESCRIPTION
If Namespace.so was to fail - Always run 2 of everything™ - we want to notify Zulip of a deploy when we fallback to the GitHub runner.