### PR TITLE
Scale down the app instance size

### DIFF
--- a/fly.io/changelog-2024-01-12/fly.toml
+++ b/fly.io/changelog-2024-01-12/fly.toml
@@ -9,8 +9,9 @@ kill_timeout = 30
 [env]
 APP_INSTANCE = "production"
 
+# https://fly.io/docs/about/pricing/
 [[vm]]
-size = "performance-4x"
+size = "performance-2x"
 
 [deploy]
 strategy = "bluegreen"

--- a/fly.io/changelog-2025-05-05/fly.toml
+++ b/fly.io/changelog-2025-05-05/fly.toml
@@ -12,8 +12,9 @@ APP_INSTANCE = "experimental"
 URL_HOST = "pipedream.changelog.com"
 STATIC_URL_HOST = "cdn2.changelog.com"
 
+# https://fly.io/docs/about/pricing/
 [[vm]]
-size = "performance-4x"
+size = "performance-2x"
 
 [deploy]
 strategy = "bluegreen"


### PR DESCRIPTION
We don't need the CPU or the memory of a `performance-4x`.

In the last 14 days, apart from a few ~85% CPU spikes that lasted a few minutes, the app is using low single-digit CPU.

![image](https://github.com/user-attachments/assets/30e322c5-561d-4d00-b99c-6c595b61f039)

Memory is at a steady `600MB` for most of the time, with some periods of increased activity that reach `800MB`. The biggest observed spike was `1.8GB`.

![image](https://github.com/user-attachments/assets/3783dcc0-ed5e-4298-abc0-6cef7692d0b5)

The `performance-2x` has plenty CPU, and also memory headroom @ `4GB`.