### PR TITLE
Promote changelog-2025-05-05.fly.dev to new production

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 # Sets current production
-export APP_PROD_INSTANCE=changelog-2024-01-12
+export APP_PROD_INSTANCE=changelog-2025-05-05
 
 # Required for op to know which account to use
 export OP_ACCOUNT=changelog.1password.com

--- a/config/config.exs
+++ b/config/config.exs
@@ -98,7 +98,7 @@ config :waffle,
 
 config :ueberauth, Ueberauth,
   providers: [
-    github: {Ueberauth.Strategy.Github, [default_scope: "user:email"]},
+    github: {Ueberauth.Strategy.Github, [default_scope: "user:email", send_redirect_uri: false]},
     twitter: {Ueberauth.Strategy.Twitter, []}
   ]
 

--- a/fly.io/changelog-2024-01-12/fly.toml
+++ b/fly.io/changelog-2024-01-12/fly.toml
@@ -7,7 +7,7 @@ kill_signal = "SIGTERM"
 kill_timeout = 30
 
 [env]
-APP_INSTANCE = "production"
+APP_INSTANCE = "production-eol-2025-10-05"
 PIPEDREAM_HOST = "cdn-2025-02-25.internal"
 
 # https://fly.io/docs/about/pricing/

--- a/fly.io/changelog-2025-05-05/fly.toml
+++ b/fly.io/changelog-2025-05-05/fly.toml
@@ -8,16 +8,11 @@ kill_timeout = 30
 
 [env]
 PIPEDREAM_HOST = "cdn-2025-02-25.internal"
-# This is not YET production - only a portion of the production traffic is currently running through this.
-# Fastly still points to changelog-2024-01-12.fly.dev, so until all traffic is routed through this new app instance, that one is the "primary" production.
-APP_INSTANCE = "pipedream-partial-production"
-# We are leaving the alternative URLs in place in case we need to roll this partial deployment back.
-# URL_HOST = "pipedream.changelog.com"
-# STATIC_URL_HOST = "cdn2.changelog.com"
+APP_INSTANCE = "production"
 
 # https://fly.io/docs/about/pricing/
 [[vm]]
-size = "performance-2x"
+size = "performance-1x"
 
 [deploy]
 strategy = "bluegreen"


### PR DESCRIPTION
The new setup has been serving production traffic for a few months now. Given all the metrics, we are confident that it's time to switch everything across.

Since 98% of the requests are cached in the new setup, we can comfortably reduce the app size by 50%, and still deliver much better performance than before. Stay tuned, we'll unpack this in:
- https://github.com/thechangelog/changelog.com/discussions/551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated infrastructure docs and diagrams to reflect Pipedream as the edge/cache provider, refreshed app/DB flow, observability paths, and current URLs/topology.

- Bug Fixes
  - Adjusted GitHub sign-in configuration affecting redirect handling.

- Chores
  - Updated production app instance identifiers and environment settings.
  - Revised deployment configuration, including VM size change and a new release command.
  - Switched CDN/edge routing to Pipedream for asset delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->