### PR TITLE
Use data-backed hosts for Changelog meta podcast

### DIFF
--- a/lib/changelog/schema/podcast/podcast.ex
+++ b/lib/changelog/schema/podcast/podcast.ex
@@ -7,7 +7,6 @@ defmodule Changelog.Podcast do
     EpisodeStat,
     FeedStat,
     Files,
-    Person,
     PodcastTopic,
     PodcastHost,
     Regexp,
@@ -121,7 +120,7 @@ defmodule Changelog.Podcast do
       clips_url: "https://www.youtube.com/playlist?list=PLCzseuA9sYreumc6MQV7C8FiRuaMczhjK",
       zulip_url: Application.get_env(:changelog, :zulip_url),
       cover: true,
-      active_hosts: Person.with_ids([1, 2]) |> Person.newest_first() |> Repo.all()
+      active_hosts: active_hosts_for_slug("podcast")
     }
   end
 
@@ -142,6 +141,17 @@ defmodule Changelog.Podcast do
     from(q in __MODULE__, where: q.slug in ~w(news podcast friends), select: [:id])
     |> Repo.all()
     |> Enum.map(& &1.id)
+  end
+
+  defp active_hosts_for_slug(slug) do
+    from(podcast in public(),
+      join: host in assoc(podcast, :active_podcast_hosts),
+      join: person in assoc(host, :person),
+      where: podcast.slug == ^slug,
+      order_by: [asc: host.position, asc: host.id],
+      select: person
+    )
+    |> Repo.all()
   end
 
   def file_changeset(podcast, attrs \\ %{}), do: cast_attachments(podcast, attrs, [:cover])

--- a/test/changelog/schema/podcast/podcast_test.exs
+++ b/test/changelog/schema/podcast/podcast_test.exs
@@ -1,7 +1,7 @@
 defmodule Changelog.PodcastTest do
   use Changelog.SchemaCase
 
-  alias Changelog.Podcast
+  alias Changelog.{Podcast, PodcastHost}
 
   describe "insert_changeset" do
     test "with valid attributes" do
@@ -37,6 +37,36 @@ defmodule Changelog.PodcastTest do
     assert Podcast.published_episode_count(podcast) == 1
   end
 
+  describe "changelog/0" do
+    test "uses the persisted podcast row active host association" do
+      podcast = insert(:podcast, slug: "podcast")
+      adam = insert(:person, name: "Adam Active")
+      future_host = insert(:person, name: "Future Active")
+      retired = insert(:person, name: "Retired Host")
+
+      Repo.insert!(%PodcastHost{
+        podcast_id: podcast.id,
+        person_id: retired.id,
+        position: 1,
+        retired: true
+      })
+
+      Repo.insert!(%PodcastHost{podcast_id: podcast.id, person_id: future_host.id, position: 2})
+      Repo.insert!(%PodcastHost{podcast_id: podcast.id, person_id: adam.id, position: 1})
+
+      meta = Podcast.changelog()
+
+      assert meta.name == "The Changelog"
+      assert meta.slug == "podcast"
+      assert meta.is_meta
+      assert Enum.map(meta.active_hosts, & &1.id) == [adam.id, future_host.id]
+    end
+
+    test "uses no active hosts when the persisted metadata row is absent" do
+      assert Podcast.changelog().active_hosts == []
+    end
+  end
+
   describe "update_stat_counts/1" do
     setup do
       {:ok, podcast: insert(:podcast)}
@@ -65,20 +95,26 @@ defmodule Changelog.PodcastTest do
     end
 
     test "it uses the most recent feed stats, ignoring < 5 subs", %{podcast: podcast} do
-      insert(:feed_stat, date: ~D[2024-01-01], podcast: podcast, agents: %{
-        "Overcast" => %{
-          "raw" => "Overcast/1.0 Podcast Sync (993 subscribers; feed-id=554901; +http://overcast.fm/)"
-        },
-        "Player FM" => %{
-          "raw" => "PlayerFM/1.0 Podcast Sync (5033 subscribers; url=https://player.fm/series/the-changelog-1282967)"
-        },
-        "Castro" => %{
-          "raw" => "Castro 2 Episode Download (1000 subscribers)"
-        },
-        "Fake Castro" => %{
-          "raw" => "Fake Castro 2 Episode Download (3 subscribers)"
+      insert(:feed_stat,
+        date: ~D[2024-01-01],
+        podcast: podcast,
+        agents: %{
+          "Overcast" => %{
+            "raw" =>
+              "Overcast/1.0 Podcast Sync (993 subscribers; feed-id=554901; +http://overcast.fm/)"
+          },
+          "Player FM" => %{
+            "raw" =>
+              "PlayerFM/1.0 Podcast Sync (5033 subscribers; url=https://player.fm/series/the-changelog-1282967)"
+          },
+          "Castro" => %{
+            "raw" => "Castro 2 Episode Download (1000 subscribers)"
+          },
+          "Fake Castro" => %{
+            "raw" => "Fake Castro 2 Episode Download (3 subscribers)"
+          }
         }
-      })
+      )
 
       podcast = Podcast.update_subscribers(podcast)
 
@@ -87,14 +123,20 @@ defmodule Changelog.PodcastTest do
       assert podcast.subscribers["Castro"] == 1000
       assert podcast.subscribers["Fake Castro"] == nil
 
-      insert(:feed_stat, date: ~D[2024-01-02], podcast: podcast, agents: %{
-        "Overcast" => %{
-          "raw" => "Overcast/1.0 Podcast Sync (994 subscribers; feed-id=554901; +http://overcast.fm/)"
-        },
-        "Player FM" => %{
-          "raw" => "PlayerFM/1.0 Podcast Sync (5133 subscribers; url=https://player.fm/series/the-changelog-1282967)"
+      insert(:feed_stat,
+        date: ~D[2024-01-02],
+        podcast: podcast,
+        agents: %{
+          "Overcast" => %{
+            "raw" =>
+              "Overcast/1.0 Podcast Sync (994 subscribers; feed-id=554901; +http://overcast.fm/)"
+          },
+          "Player FM" => %{
+            "raw" =>
+              "PlayerFM/1.0 Podcast Sync (5133 subscribers; url=https://player.fm/series/the-changelog-1282967)"
+          }
         }
-      })
+      )
 
       podcast = Podcast.update_subscribers(podcast)
 

--- a/test/changelog_web/controllers/podcast_controller_test.exs
+++ b/test/changelog_web/controllers/podcast_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule ChangelogWeb.PodcastControllerTest do
   use ChangelogWeb.ConnCase
 
+  alias Changelog.PodcastHost
+
   test "getting the podcasts index", %{conn: conn} do
     p1 = insert(:podcast, slug: "news")
     p2 = insert(:podcast, slug: "friends")
@@ -47,6 +49,27 @@ defmodule ChangelogWeb.PodcastControllerTest do
     conn = get(conn, Routes.podcast_path(conn, :show, p.slug))
     assert html_response(conn, 200) =~ p.name
     assert String.contains?(conn.resp_body, i.headline)
+  end
+
+  test "getting the changelog meta podcast page uses persisted active hosts", %{conn: conn} do
+    podcast = insert(:podcast, slug: "podcast")
+    active = insert(:person, name: "Active Meta Host")
+    retired = insert(:person, name: "Retired Meta Host")
+
+    Repo.insert!(%PodcastHost{podcast_id: podcast.id, person_id: active.id, position: 1})
+
+    Repo.insert!(%PodcastHost{
+      podcast_id: podcast.id,
+      person_id: retired.id,
+      position: 2,
+      retired: true
+    })
+
+    conn = get(conn, Routes.podcast_path(conn, :show, "podcast"))
+
+    body = html_response(conn, 200)
+    assert body =~ active.name
+    refute body =~ retired.name
   end
 
   test "getting a podcast page that doesn't exist", %{conn: conn} do


### PR DESCRIPTION
## Summary
- replace the hard-coded `Person.with_ids([1, 2])` host list in `Podcast.changelog/0`
- source `/podcast` show-level active hosts from the persisted `podcast` row's active `podcast_hosts` association
- add schema and controller regression tests for active-vs-retired meta hosts

## Verification
- `mise exec -- mix test test/changelog/schema/podcast_test.exs test/changelog_web/controllers/podcast_controller_test.exs`
- `mise run test`
- `git diff --check`

## Notes
- Local `mise run docker:test` is waived for this PR because the Apple Silicon Docker path fails before app tests while compiling dependencies under amd64 emulation. CI should be the Docker authority for this branch.
- No database changes are included. PEP-0011 covers the later DB uniqueness rollout separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Podcast changelogs now display the persisted active hosts in the correct order.
  * Retired hosts are excluded from podcast changelog metadata and pages.
  * Podcasts without persisted active hosts no longer show incorrect host information.

* **Tests**
  * Added coverage for active and retired host handling, host ordering, and podcasts without metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->